### PR TITLE
fix coredump issue when creating multiple raft groups concurrently in meta merge mode

### DIFF
--- a/src/braft/raft_meta.cpp
+++ b/src/braft/raft_meta.cpp
@@ -106,7 +106,7 @@ private:
     typedef butil::DoublyBufferedData<MetaStorageMap> DoublyBufferedMetaStorageMap;
     
     static size_t _add(MetaStorageMap& m, const std::string& path, 
-                       const scoped_refptr<KVBasedMergedMetaStorageImpl> mss) {
+                       const scoped_refptr<KVBasedMergedMetaStorageImpl>& mss) {
         std::pair<MetaStorageMap::const_iterator, bool> iter = 
                                         m.insert(std::make_pair(path, mss));
         if (iter.second) {

--- a/src/braft/raft_meta.h
+++ b/src/braft/raft_meta.h
@@ -143,11 +143,12 @@ friend class scoped_refptr<KVBasedMergedMetaStorageImpl>;
 
 public:
     explicit KVBasedMergedMetaStorageImpl(const std::string& path)
-        : _is_inited(false), _path(path) {}
+        : _is_inited(false), _path(path), _db(nullptr) {}
     KVBasedMergedMetaStorageImpl() {}
     virtual ~KVBasedMergedMetaStorageImpl() {
         if (_db) {
             delete _db;
+            _db = nullptr;
         }
     }
     


### PR DESCRIPTION
When create 128 raft groups concurrently in meta-merge mode,  the server cores at register_meta_storage due to segment fault error. It seems that in the  ~KVBasedMergedMetaStorageImpl destructor, the _db doesn't point to a valid memory address since it hasn't been initialize properly in the constructor.

![image](https://user-images.githubusercontent.com/4198752/82518245-7f61e600-9b51-11ea-89f2-1d4311ba052f.png)

 This issue is gone with this modification.
