### PR TITLE
fix #214 last_msg_to_now not update

### DIFF
--- a/src/braft/lease.cpp
+++ b/src/braft/lease.cpp
@@ -104,6 +104,10 @@ void FollowerLease::renew(const PeerId& leader_id) {
     _last_leader_timestamp = butil::monotonic_time_ms();
 }
 
+int64_t FollowerLease::last_msg_to_now() {
+    return butil::monotonic_time_ms() - _last_leader_timestamp;
+}
+
 int64_t FollowerLease::votable_time_from_now() {
     if (!FLAGS_raft_enable_leader_lease) {
         return 0;

--- a/src/braft/lease.h
+++ b/src/braft/lease.h
@@ -70,6 +70,7 @@ public:
 
     void init(int64_t election_timeout_ms, int64_t max_clock_drift_ms);
     void renew(const PeerId& leader_id);
+    int64_t last_msg_to_now();
     int64_t votable_time_from_now();
     const PeerId& last_leader();
     bool expired();

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -128,7 +128,6 @@ static inline int heartbeat_timeout(int election_timeout) {
 NodeImpl::NodeImpl(const GroupId& group_id, const PeerId& peer_id)
     : _state(STATE_UNINITIALIZED)
     , _current_term(0)
-    , _last_leader_timestamp(butil::monotonic_time_ms())
     , _group_id(group_id)
     , _server_id(peer_id)
     , _conf_ctx(this)
@@ -155,7 +154,6 @@ NodeImpl::NodeImpl(const GroupId& group_id, const PeerId& peer_id)
 NodeImpl::NodeImpl()
     : _state(STATE_UNINITIALIZED)
     , _current_term(0)
-    , _last_leader_timestamp(butil::monotonic_time_ms())
     , _group_id()
     , _server_id()
     , _conf_ctx(this)
@@ -2537,7 +2535,6 @@ void NodeImpl::describe(std::ostream& os, bool use_html) {
 
     // No replicator attached to nodes that are not leader;
     _replicator_group.list_replicators(&replicators);
-    const int64_t leader_timestamp = _last_leader_timestamp;
     const bool readonly = (_node_readonly || _majority_nodes_readonly);
     lck.unlock();
     const char *newline = use_html ? "<br>" : "\r\n";
@@ -2606,7 +2603,7 @@ void NodeImpl::describe(std::ostream& os, bool use_html) {
             os << leader;
         }
         os << newline;
-        os << "last_msg_to_now: " << butil::monotonic_time_ms() - leader_timestamp 
+        os << "last_msg_to_now: " << _follower_lease.last_msg_to_now()
            << newline;
     }
 

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -465,7 +465,6 @@ private:
 
     State _state;
     int64_t _current_term;
-    int64_t _last_leader_timestamp;
     PeerId _leader_id;
     PeerId _voted_id;
     VoteBallotCtx _vote_ctx; // candidate vote ctx


### PR DESCRIPTION
修复follower raft_stat 中 last_msg_to_now 不更新的问题