### PR TITLE
No need destroy replicator in _on_rpc_returned

### DIFF
--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -416,7 +416,6 @@ void Replicator::_on_rpc_returned(ReplicatorId id, brpc::Controller* cntl,
             butil::Status status;
             status.set_error(EHIGHERTERMRESPONSE, "Leader receives higher term "
                     "%s from peer:%s", response->GetTypeName().c_str(), r->_options.peer_id.to_string().c_str());
-            r->_destroy();
             node_impl->increase_term_to(response->term(), status);
             node_impl->Release();
             return;

--- a/src/braft/replicator.h
+++ b/src/braft/replicator.h
@@ -287,7 +287,7 @@ public:
     // NOTE: when calling this function, the replicatos starts to work
     // immediately, annd might call node->step_down which might have race with
     // the caller, you should deal with this situation.
-    int add_replicator(const PeerId &peer);
+    int add_replicator(const PeerId& peer);
     
     // wait the very peer catchup
     int wait_caughtup(const PeerId& peer, int64_t max_margin,


### PR DESCRIPTION
when node step down called by increase_term_to, would call _replicator_group.stop_all(), which would stop and destroy all replicators. Therefore need not destroy replicator in advance in _on_heartbeat_returned function.