### PR TITLE
Fix compatible with Mac and Brpc's defer close problem

### DIFF
--- a/example/atomic/client.cpp
+++ b/example/atomic/client.cpp
@@ -134,16 +134,20 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
+    std::vector<pthread_t> pids;
+
     std::vector<SendArg> args;
     for (int i = 1; i <= FLAGS_thread_num; ++i) {
         SendArg arg = { i };
         args.push_back(arg);
     }
+
     tids.resize(FLAGS_thread_num);
+    pids.resize(FLAGS_thread_num);
     if (!FLAGS_use_bthread) {
         for (int i = 0; i < FLAGS_thread_num; ++i) {
             if (pthread_create(
-                        &tids[i], NULL, sender, &args[i]) != 0) {
+                        &pids[i], NULL, sender, &args[i]) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
@@ -170,7 +174,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Counter client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }

--- a/example/atomic/run_client.sh
+++ b/example/atomic/run_client.sh
@@ -49,6 +49,7 @@ export TCMALLOC_SAMPLE_PARAMETER=524288
 
 ${VALGRIND} ./atomic_client \
         --add_percentage=${FLAGS_add_percentage} \
+        --defer_close_second=1 \
         --bthread_concurrency=${FLAGS_bthread_concurrency} \
         --conf="${raft_peers}" \
         --log_each_request=${FLAGS_log_each_request} \

--- a/example/block/client.cpp
+++ b/example/block/client.cpp
@@ -122,10 +122,12 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
+		std::vector<pthread_t> pids;
     tids.resize(FLAGS_thread_num);
+		pids.resize(FLAGS_thread_num);
     if (!FLAGS_use_bthread) {
         for (int i = 0; i < FLAGS_thread_num; ++i) {
-            if (pthread_create(&tids[i], NULL, sender, NULL) != 0) {
+            if (pthread_create(&pids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
@@ -151,7 +153,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Block client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }

--- a/example/block/run_client.sh
+++ b/example/block/run_client.sh
@@ -50,6 +50,7 @@ export TCMALLOC_SAMPLE_PARAMETER=524288
 
 ${VALGRIND} ./block_client \
         --write_percentage=${FLAGS_write_percentage} \
+        --defer_close_second=1 \
         --bthread_concurrency=${FLAGS_bthread_concurrency} \
         --conf="${raft_peers}" \
         --crash_on_fatal_log=${FLAGS_crash_on_fatal} \

--- a/example/block/server.cpp
+++ b/example/block/server.cpp
@@ -26,7 +26,7 @@
 
 #ifdef __APPLE__
 #define fdatasync fsync
-#define fread_unlocked freed
+#define fread_unlocked fread
 #endif
 
 

--- a/example/block/server.cpp
+++ b/example/block/server.cpp
@@ -23,6 +23,13 @@
 #include <braft/util.h>                 // braft::AsyncClosureGuard
 #include "block.pb.h"                   // BlockService
 
+
+#ifdef __APPLE__
+#define fdatasync fsync
+#define fread_unlocked freed
+#endif
+
+
 DEFINE_bool(check_term, true, "Check if the leader changed to another term");
 DEFINE_bool(disable_cli, false, "Don't allow raft_cli access this node");
 DEFINE_bool(log_applied_task, false, "Print notice log when a task is applied");

--- a/example/counter/client.cpp
+++ b/example/counter/client.cpp
@@ -112,10 +112,12 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
+    std::vector<pthread_t> pids;
     tids.resize(FLAGS_thread_num);
+    pids.resize(FLAGS_thread_num);
     if (!FLAGS_use_bthread) {
         for (int i = 0; i < FLAGS_thread_num; ++i) {
-            if (pthread_create(&tids[i], NULL, sender, NULL) != 0) {
+            if (pthread_create(&pids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
@@ -141,7 +143,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Counter client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }

--- a/example/counter/run_client.sh
+++ b/example/counter/run_client.sh
@@ -50,6 +50,7 @@ export TCMALLOC_SAMPLE_PARAMETER=524288
 
 ${VALGRIND} ./counter_client \
         --add_percentage=${FLAGS_add_percentage} \
+        --defer_close_second=1 \
         --bthread_concurrency=${FLAGS_bthread_concurrency} \
         --conf="${raft_peers}" \
         --crash_on_fatal_log=${FLAGS_crash_on_fatal} \


### PR DESCRIPTION
1. Compatible with Mac OSX (without fdatasync system call)
2. Make a difference between `pthread_id` and `bthread_id` (can't use
   &bthread_id as pthread_* functions's argument)
3. Brpc's problem (the client side ERROR: "can't assign requested
   address"), we should add '--defer_close_second' flag.