### PR TITLE
LogManager::disk_thread run closures in bthread after the log manager…

### DIFF
--- a/src/braft/log_manager.h
+++ b/src/braft/log_manager.h
@@ -207,6 +207,7 @@ friend class AppendBatcher;
     raft_mutex_t _mutex;
     butil::FlatMap<int64_t, WaitMeta*> _wait_map;
     bool _stopped;
+    bool _shutdown;
     butil::atomic<bool> _has_error;
     WaitId _next_wait_id;
 


### PR DESCRIPTION
… shutdown, to avoid deadlock.

In the situation, the closure may hold the last reference of NodeImpl, and done->Run() triggers the
the destructor of NodeImpl. In the destructor, NodeImpl joins the disk thread to terminate, but
the done->Run() itself is excuted in the disk thread. The disk thread can never be terminated!