### PR TITLE
add node should support more time than election_timeout_ms, since rem…

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -724,7 +724,7 @@ void NodeImpl::on_caughtup(const PeerId& peer, int64_t term,
 
         OnCaughtUp* caught_up = new OnCaughtUp(this, _current_term, peer, version);
         timespec due_time = butil::milliseconds_from_now(
-                _options.election_timeout_ms);
+                _options.get_catchup_timeout_ms());
 
         if (0 == _replicator_group.wait_caughtup(
                     peer, _options.catchup_margin, &due_time, caught_up)) {
@@ -3040,7 +3040,7 @@ void NodeImpl::ConfigurationCtx::start(const Configuration& old_conf,
         OnCaughtUp* caught_up = new OnCaughtUp(
                 _node, _node->_current_term, *iter, _version);
         timespec due_time = butil::milliseconds_from_now(
-                _node->_options.election_timeout_ms);
+                _node->_options.get_catchup_timeout_ms());
         if (_node->_replicator_group.wait_caughtup(
             *iter, _node->_options.catchup_margin, &due_time, caught_up) != 0) {
             LOG(WARNING) << "node " << _node->node_id()

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -480,6 +480,11 @@ struct NodeOptions {
     // Default: 1000 (1s)
     int election_timeout_ms; //follower to candidate timeout
 
+    // wait new peer to catchup log in |catchup_timeout_ms| milliseconds
+    // if set to 0, it will same as election_timeout_ms
+    // Default: 0
+    int catchup_timeout_ms;
+
     // Max clock drift time. It will be used to keep the safety of leader lease.
     // Default: 1000 (1s)
     int max_clock_drift_ms;
@@ -585,10 +590,13 @@ struct NodeOptions {
 
     // Construct a default instance
     NodeOptions();
+
+    int get_catchup_timeout_ms();
 };
 
 inline NodeOptions::NodeOptions() 
     : election_timeout_ms(1000)
+    , catchup_timeout_ms(0)
     , max_clock_drift_ms(1000)
     , snapshot_interval_s(3600)
     , catchup_margin(1000)
@@ -602,6 +610,10 @@ inline NodeOptions::NodeOptions()
     , snapshot_throttle(NULL)
     , disable_cli(false)
 {}
+
+inline int NodeOptions::get_catchup_timeout_ms() {
+    return (catchup_timeout_ms == 0) ? election_timeout_ms : catchup_timeout_ms;
+}
 
 class NodeImpl;
 class Node {


### PR DESCRIPTION
catchup when add node should support wait more time than election_timeout_ms, since remote node maybe not ready soon.
so add a new field to specified the catchup wait time, and default value is same as election_timeout_ms to keep compatibility。