### PR TITLE
fix deadlock, caused by not destroy replicator when receive higher term

### DIFF
--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -416,6 +416,7 @@ void Replicator::_on_rpc_returned(ReplicatorId id, brpc::Controller* cntl,
             butil::Status status;
             status.set_error(EHIGHERTERMRESPONSE, "Leader receives higher term "
                     "%s from peer:%s", response->GetTypeName().c_str(), r->_options.peer_id.to_string().c_str());
+            r->_destroy();
             node_impl->increase_term_to(response->term(), status);
             node_impl->Release();
             return;


### PR DESCRIPTION
below two call flow will lead to deadlock

1. this call flow will hold lock of nodeimpl, and try to lock replicator
NodeImpl::handle_request_vote_request 
NodeImpl::step_down
ReplicatorGroup::stop_all
Replicator::stop
bthread_id_lock


2. this call flow hold lock of replicator, and try to lock nodeimpl
Replicator::_on_rpc_returned
NodeImpl::increase_term_to
