### PR TITLE
Fix a issue that vote/transfer leader is difficult to succeed, if leader lease is enabled and quorum > 2.

### DIFF
--- a/src/braft/lease.cpp
+++ b/src/braft/lease.cpp
@@ -136,6 +136,10 @@ void FollowerLease::reset() {
     _last_leader_timestamp = 0;
 }
 
+void FollowerLease::expire() {
+    _last_leader_timestamp = 0;
+}
+
 void FollowerLease::reset_election_timeout_ms(int64_t election_timeout_ms,
                                               int64_t max_clock_drift_ms) {
     _election_timeout_ms = election_timeout_ms;

--- a/src/braft/lease.h
+++ b/src/braft/lease.h
@@ -74,6 +74,7 @@ public:
     const PeerId& last_leader();
     bool expired();
     void reset();
+    void expire();
     void reset_election_timeout_ms(int64_t election_timeout_ms, int64_t max_clock_drift_ms);
     int64_t last_leader_timestamp();
 

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -61,6 +61,8 @@ DEFINE_bool(raft_trace_append_entry_latency, false,
             "trace append entry latency");
 BRPC_VALIDATE_GFLAG(raft_trace_append_entry_latency, brpc::PassValidate);
 
+DECLARE_bool(raft_enable_leader_lease);
+
 #ifndef UNIT_TEST
 static bvar::Adder<int64_t> g_num_nodes("raft_node_count");
 #else
@@ -1011,6 +1013,7 @@ void NodeImpl::handle_election_timeout() {
 
         return;
     }
+    bool triggered = _vote_triggered;
     _vote_triggered = false;
 
     // Reset leader as the leader is uncerntain on election timeout.
@@ -1020,7 +1023,7 @@ void NodeImpl::handle_election_timeout() {
                                     _leader_id.to_string().c_str());
     reset_leader_id(empty_id, status);
 
-    return pre_vote(&lck);
+    return pre_vote(&lck, triggered);
     // Don't touch any thing of *this ever after
 }
 
@@ -1061,8 +1064,14 @@ void NodeImpl::handle_timeout_now_request(brpc::Controller* controller,
     }
     const butil::EndPoint remote_side = controller->remote_side();
     const int64_t saved_term = _current_term;
-    // Increase term to make leader step down
-    response->set_term(_current_term + 1);
+    if (FLAGS_raft_enable_leader_lease) {
+        // We will disrupt the leader, don't let the old leader
+        // step down.
+        response->set_term(_current_term);
+    } else {
+        // Increase term to make leader step down
+        response->set_term(_current_term + 1);
+    }
     response->set_success(true);
     // Parallelize Response and election
     run_closure_in_bthread(done_guard.release());
@@ -1297,7 +1306,7 @@ void NodeImpl::handle_vote_timeout() {
         butil::Status status;
         status.set_error(ERAFTTIMEDOUT, "Fail to get quorum vote-granted");
         step_down(_current_term, false, status);
-        pre_vote(&lck);
+        pre_vote(&lck, false);
     } else {
         // retry vote
         LOG(WARNING) << "node " << _group_id << ":" << _server_id
@@ -1347,8 +1356,16 @@ void NodeImpl::handle_request_vote_response(const PeerId& peer_id, const int64_t
 
     LOG(INFO) << "node " << _group_id << ":" << _server_id
               << " received RequestVoteResponse from " << peer_id
-              << " term " << response.term() << " granted " << response.granted();
-    // check if the quorum granted
+              << " term " << response.term() << " granted " << response.granted()
+              << " rejected_by_lease " << response.rejected_by_lease()
+              << " disrupted " << response.disrupted();
+    if (!response.granted() && !response.rejected_by_lease()) {
+        return;
+    }
+
+    if (response.disrupted()) {
+        _vote_ctx.set_disrupted_leader(DisruptedLeader(peer_id, response.previous_term()));
+    }
     if (response.granted()) {
         _vote_ctx.grant(peer_id);
         if (peer_id == _follower_lease.last_leader()) {
@@ -1356,9 +1373,23 @@ void NodeImpl::handle_request_vote_response(const PeerId& peer_id, const int64_t
             _vote_ctx.stop_grant_self_timer(this);
         }
         if (_vote_ctx.granted()) {
-            become_leader();
+            return become_leader();
         }
+    } else {
+        // If the follower rejected the vote because of lease, reserve it, and
+        // the candidate will try again after it disrupt the old leader.
+        _vote_ctx.reserve(peer_id);
     }
+    retry_vote_on_reserved_peers();
+}
+
+void NodeImpl::retry_vote_on_reserved_peers() {
+    std::set<PeerId> peers;
+    _vote_ctx.pop_grantable_peers(&peers);
+    if (peers.empty()) {
+        return;
+    }
+    request_peers_to_vote(peers, &_vote_ctx.disrupted_leader());
 }
 
 struct OnRequestVoteRPCDone : public google::protobuf::Closure {
@@ -1402,7 +1433,7 @@ void NodeImpl::handle_pre_vote_response(const PeerId& peer_id, const int64_t ter
         LOG(WARNING) << "node " << _group_id << ":" << _server_id
                      << " received invalid PreVoteResponse from " << peer_id
                      << " ctx_version " << ctx_version
-                     << "current_ctx_version " << _pre_vote_ctx.version();
+                     << " current_ctx_version " << _pre_vote_ctx.version();
         return;
     }
 
@@ -1434,17 +1465,43 @@ void NodeImpl::handle_pre_vote_response(const PeerId& peer_id, const int64_t ter
 
     LOG(INFO) << "node " << _group_id << ":" << _server_id
               << " received PreVoteResponse from " << peer_id
-              << " term " << response.term() << " granted " << response.granted();
-    // check if the quorum granted
-    if (response.granted()) {
-        _pre_vote_ctx.grant(peer_id);
-        if (peer_id == _follower_lease.last_leader()) {
+              << " term " << response.term() << " granted " << response.granted()
+              << " rejected_by_lease " << response.rejected_by_lease()
+              << " disrupted " << response.disrupted();
+
+    if (!response.granted() && !response.rejected_by_lease()) {
+        return;
+    }
+
+    // Internal vote should respect lease.
+    if (response.rejected_by_lease() && !_pre_vote_ctx.triggered()) {
+        return;
+    }
+
+    if (response.disrupted()) {
+        _pre_vote_ctx.set_disrupted_leader(DisruptedLeader(peer_id, response.previous_term()));
+    }
+    std::set<PeerId> peers;
+    if (response.rejected_by_lease()) {
+        // Temporarily reserve the vote of follower because the lease is
+        // still valid. Until we make sure the leader can be disrupted,
+        // the vote can't be counted.
+        _pre_vote_ctx.reserve(peer_id);
+        _pre_vote_ctx.pop_grantable_peers(&peers);
+    } else {
+        _pre_vote_ctx.pop_grantable_peers(&peers);
+        peers.insert(peer_id);
+    }
+    for (std::set<PeerId>::const_iterator it = peers.begin();
+            it != peers.end(); ++it) {
+        _pre_vote_ctx.grant(*it);
+        if (*it == _follower_lease.last_leader()) {
             _pre_vote_ctx.grant(_server_id);
             _pre_vote_ctx.stop_grant_self_timer(this);
         }
-        if (_pre_vote_ctx.granted()) {
-            elect_self(&lck);
-        }
+    }
+    if (_pre_vote_ctx.granted()) {
+        elect_self(&lck);
     }
 }
 
@@ -1480,7 +1537,7 @@ struct OnPreVoteRPCDone : public google::protobuf::Closure {
     NodeImpl* node;
 };
 
-void NodeImpl::pre_vote(std::unique_lock<raft_mutex_t>* lck) {
+void NodeImpl::pre_vote(std::unique_lock<raft_mutex_t>* lck, bool triggered) {
     LOG(INFO) << "node " << _group_id << ":" << _server_id
               << " term " << _current_term << " start pre_vote";
     if (_snapshot_executor && _snapshot_executor->is_installing_snapshot()) {
@@ -1508,7 +1565,7 @@ void NodeImpl::pre_vote(std::unique_lock<raft_mutex_t>* lck) {
         return;
     }
 
-    _pre_vote_ctx.init(this);
+    _pre_vote_ctx.init(this, triggered);
     std::set<PeerId> peers;
     _conf.list_peers(&peers);
 
@@ -1573,7 +1630,7 @@ void NodeImpl::elect_self(std::unique_lock<raft_mutex_t>* lck) {
                << " term " << _current_term << " start vote_timer";
     _vote_timer.start();
     _pre_vote_ctx.reset(this);
-    _vote_ctx.init(this);
+    _vote_ctx.init(this, false);
 
     int64_t old_term = _current_term;
     // get last_log_id outof node mutex
@@ -1587,9 +1644,29 @@ void NodeImpl::elect_self(std::unique_lock<raft_mutex_t>* lck) {
                      << " raise term " << _current_term << " when get last_log_id";
         return;
     }
+    _vote_ctx.set_last_log_id(last_log_id);
+
     std::set<PeerId> peers;
     _conf.list_peers(&peers);
+    request_peers_to_vote(peers, NULL);
 
+    //TODO: outof lock
+    status = _meta_storage->
+                    set_term_and_votedfor(_current_term, _server_id, _v_group_id);
+    if (!status.ok()) {
+        LOG(ERROR) << "node " << _group_id << ":" << _server_id
+                   << " fail to set_term_and_votedfor itself when elect_self,"
+                      " error: " << status;
+        // reset _voted_id to avoid inconsistent cases
+        // return immediately without granting _vote_ctx
+        _voted_id.reset();
+        return;
+    }
+    grant_self(&_vote_ctx, lck);
+}
+
+void NodeImpl::request_peers_to_vote(const std::set<PeerId>& peers,
+                                     const NodeImpl::DisruptedLeader* disrupted_leader) {
     for (std::set<PeerId>::const_iterator
         iter = peers.begin(); iter != peers.end(); ++iter) {
         if (*iter == _server_id) {
@@ -1612,25 +1689,19 @@ void NodeImpl::elect_self(std::unique_lock<raft_mutex_t>* lck) {
         done->request.set_server_id(_server_id.to_string());
         done->request.set_peer_id(iter->to_string());
         done->request.set_term(_current_term);
-        done->request.set_last_log_index(last_log_id.index);
-        done->request.set_last_log_term(last_log_id.term);
+        done->request.set_last_log_index(_vote_ctx.last_log_id().index);
+        done->request.set_last_log_term(_vote_ctx.last_log_id().term);
+
+        if (disrupted_leader) {
+            done->request.mutable_disrupted_leader()
+                ->set_peer_id(disrupted_leader->peer_id.to_string());
+            done->request.mutable_disrupted_leader()
+                ->set_term(disrupted_leader->term);
+        }
 
         RaftService_Stub stub(&channel);
         stub.request_vote(&done->cntl, &done->request, &done->response, done);
     }
-
-    //TODO: outof lock
-    status = _meta_storage->
-                    set_term_and_votedfor(_current_term, _server_id, _v_group_id);
-    if (!status.ok()) {
-         LOG(ERROR) << "node " << _group_id << ":" << _server_id
-                   << " fail to set_term_and_votedfor itself when elect_self,"
-                      " error: " << status;
-         // reset _voted_id to avoid inconsistent cases
-         // return immediately without granting _vote_ctx
-         _voted_id.reset(); 
-    }
-    grant_self(&_vote_ctx, lck);
 }
 
 // in lock
@@ -1974,15 +2045,14 @@ int NodeImpl::handle_pre_vote_request(const RequestVoteRequest* request,
     }
 
     bool granted = false;
+    bool rejected_by_lease = false;
     do {
-        int64_t votable_time = _follower_lease.votable_time_from_now();
-        if (request->term() < _current_term || votable_time > 0) {
+        if (request->term() < _current_term) {
             // ignore older term
             LOG(INFO) << "node " << _group_id << ":" << _server_id
                       << " ignore PreVote from " << request->server_id()
                       << " in term " << request->term()
-                      << " current_term " << _current_term
-                      << " votable_time_from_now " << votable_time;
+                      << " current_term " << _current_term;
             break;
         }
 
@@ -1992,19 +2062,29 @@ int NodeImpl::handle_pre_vote_request(const RequestVoteRequest* request,
         lck.lock();
         // pre_vote not need ABA check after unlock&lock
 
-        granted = (LogId(request->last_log_index(), request->last_log_term())
+        int64_t votable_time = _follower_lease.votable_time_from_now();
+        bool grantable = (LogId(request->last_log_index(), request->last_log_term())
                         >= last_log_id);
+        if (grantable) {
+            granted = (votable_time == 0);
+            rejected_by_lease = (votable_time > 0);
+        }
 
         LOG(INFO) << "node " << _group_id << ":" << _server_id
                   << " received PreVote from " << request->server_id()
                   << " in term " << request->term()
                   << " current_term " << _current_term
-                  << " granted " << granted;
+                  << " granted " << granted
+                  << " rejected_by_lease " << rejected_by_lease;
 
     } while (0);
 
     response->set_term(_current_term);
     response->set_granted(granted);
+    response->set_rejected_by_lease(rejected_by_lease);
+    response->set_disrupted(_state == STATE_LEADER);
+    response->set_previous_term(_current_term);
+
     return 0;
 }
 
@@ -2031,28 +2111,28 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
         return EINVAL;
     }
 
+    PeerId disrupted_leader_id;
+    if (_state == STATE_FOLLOWER &&
+            request->has_disrupted_leader() &&
+            _current_term == request->disrupted_leader().term() &&
+            0 == disrupted_leader_id.parse(request->disrupted_leader().peer_id()) &&
+            _leader_id == disrupted_leader_id) {
+        // The candidate has already disrupted the old leader, we
+        // can expire the lease safely.
+        _follower_lease.expire();
+    }
+
+    bool disrupted = false;
+    int64_t previous_term = _current_term;
+    bool rejected_by_lease = false;
     do {
-        // check term
-        int64_t votable_time = _follower_lease.votable_time_from_now();
-        if (request->term() >= _current_term && votable_time == 0) {
-            LOG(INFO) << "node " << _group_id << ":" << _server_id
-                      << " received RequestVote from " << request->server_id()
-                      << " in term " << request->term()
-                      << " current_term " << _current_term;
-            // incress current term, change state to follower
-            if (request->term() > _current_term) {
-                butil::Status status;
-                status.set_error(EHIGHERTERMREQUEST, "Raft node receives higher term "
-                        "request_vote_request.");
-                step_down(request->term(), false, status);
-            }
-        } else {
+        // ignore older term
+        if (request->term() < _current_term) {
             // ignore older term
             LOG(INFO) << "node " << _group_id << ":" << _server_id
                       << " ignore RequestVote from " << request->server_id()
                       << " in term " << request->term()
-                      << " current_term " << _current_term
-                      << " votable_time_from_now " << votable_time;
+                      << " current_term " << _current_term;
             break;
         }
 
@@ -2060,8 +2140,9 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
         lck.unlock();
         LogId last_log_id = _log_manager->last_log_id(true);
         lck.lock();
+
         // vote need ABA check after unlock&lock
-        if (request->term() != _current_term) {
+        if (previous_term != _current_term) {
             LOG(WARNING) << "node " << _group_id << ":" << _server_id
                          << " raise term " << _current_term << " when get last_log_id";
             break;
@@ -2069,6 +2150,30 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
 
         bool log_is_ok = (LogId(request->last_log_index(), request->last_log_term())
                           >= last_log_id);
+        int64_t votable_time = _follower_lease.votable_time_from_now();
+
+        LOG(INFO) << "node " << _group_id << ":" << _server_id
+                  << " received RequestVote from " << request->server_id()
+                  << " in term " << request->term()
+                  << " current_term " << _current_term
+                  << " log_is_ok " << log_is_ok
+                  << " votable_time " << votable_time;
+
+        // if the vote is rejected by lease, tell the candidate
+        if (votable_time > 0) {
+            rejected_by_lease = log_is_ok;
+            break;
+        }
+
+        // increase current term, change state to follower
+        if (request->term() > _current_term) {
+            butil::Status status;
+            status.set_error(EHIGHERTERMREQUEST, "Raft node receives higher term "
+                    "request_vote_request.");
+            disrupted = (_state <= STATE_TRANSFERRING);
+            step_down(request->term(), false, status);
+        }
+
         // save
         if (log_is_ok && _voted_id.is_empty()) {
             butil::Status status;
@@ -2090,8 +2195,11 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
         }
     } while (0);
 
+    response->set_disrupted(disrupted);
+    response->set_previous_term(previous_term);
     response->set_term(_current_term);
     response->set_granted(request->term() == _current_term && _voted_id == candidate_id);
+    response->set_rejected_by_lease(rejected_by_lease);
     return 0;
 }
 
@@ -3280,10 +3388,10 @@ void NodeImpl::get_leader_lease_status(LeaderLeaseStatus* lease_status) {
     }
 }
 
-void NodeImpl::VoteBallotCtx::init(NodeImpl* node) {
-    ++_version;
+void NodeImpl::VoteBallotCtx::init(NodeImpl* node, bool triggered) {
+    reset(node);
     _ballot.init(node->_conf.conf, node->_conf.stable() ? NULL : &(node->_conf.old_conf));
-    stop_grant_self_timer(node);
+    _triggered = triggered;
 }
 
 void NodeImpl::VoteBallotCtx::start_grant_self_timer(int64_t wait_ms, NodeImpl* node) {
@@ -3319,6 +3427,38 @@ void NodeImpl::VoteBallotCtx::stop_grant_self_timer(NodeImpl* node) {
 void NodeImpl::VoteBallotCtx::reset(NodeImpl* node) {
     stop_grant_self_timer(node);
     ++_version;
+    _triggered = false;
+    _last_log_id = LogId();
+    _disrupted_leader = DisruptedLeader();
+    _reserved_peers.clear();
+}
+
+void NodeImpl::VoteBallotCtx::reserve(const PeerId& peer) {
+    _reserved_peers.insert(peer);
+}
+
+void NodeImpl::VoteBallotCtx::set_disrupted_leader(const DisruptedLeader& peer) {
+    _disrupted_leader = peer;
+}
+
+const NodeImpl::DisruptedLeader& NodeImpl::VoteBallotCtx::disrupted_leader() const {
+    return _disrupted_leader;
+}
+
+void NodeImpl::VoteBallotCtx::pop_grantable_peers(std::set<PeerId>* peers) {
+    peers->clear();
+    if (_disrupted_leader.term == -1) {
+        return;
+    }
+    _reserved_peers.swap(*peers);
+}
+
+void NodeImpl::VoteBallotCtx::set_last_log_id(const LogId& log_id) {
+    _last_log_id = log_id;
+}
+
+const LogId& NodeImpl::VoteBallotCtx::last_log_id() const {
+    return _last_log_id;
 }
 
 void NodeImpl::grant_self(VoteBallotCtx* vote_ctx, std::unique_lock<raft_mutex_t>* lck) {

--- a/src/braft/raft.proto
+++ b/src/braft/raft.proto
@@ -16,6 +16,11 @@ message EntryMeta {
     repeated string old_peers = 5;
 };
 
+message TermLeader {
+    required string peer_id = 1;
+    required int64 term = 2;
+};
+
 message RequestVoteRequest {
     required string group_id = 1;
     required string server_id = 2;
@@ -23,11 +28,15 @@ message RequestVoteRequest {
     required int64 term = 4;
     required int64 last_log_term = 5;
     required int64 last_log_index = 6;
+    optional TermLeader disrupted_leader = 7;
 };
 
 message RequestVoteResponse {
     required int64 term = 1;
     required bool granted = 2;
+    optional bool disrupted = 3;
+    optional int64 previous_term = 4;
+    optional bool rejected_by_lease = 5;
 };
 
 message AppendEntriesRequest {

--- a/test/test_leader_lease.cpp
+++ b/test/test_leader_lease.cpp
@@ -26,7 +26,7 @@ DECLARE_bool(raft_enable_leader_lease);
 DECLARE_int32(raft_election_heartbeat_factor);
 }
 
-class LeaseTest : public testing::Test {
+class BaseLeaseTest : public testing::Test {
 protected:
     void SetUp() {
         ::system("rm -rf data");
@@ -39,6 +39,23 @@ protected:
     void TearDown() {
         ::system("rm -rf data");
     }
+};
+
+class ExtendLeaseTest : public testing::TestWithParam<int> {
+protected:
+    void SetUp() {
+        ::system("rm -rf data");
+        //logging::FLAGS_v = 90;
+        braft::FLAGS_raft_sync = false;
+        braft::FLAGS_raft_enable_leader_lease = true;
+        braft::FLAGS_raft_election_heartbeat_factor = 3;
+        peer_num = GetParam();
+    }
+    void TearDown() {
+        ::system("rm -rf data");
+    }
+
+    int peer_num;
 };
 
 void check_if_stale_leader_exist(Cluster* cluster, int line) {
@@ -102,7 +119,7 @@ void* check_lease_in_thread(void* arg) {
     return NULL;
 }
 
-TEST_F(LeaseTest, triple_node) {
+TEST_F(BaseLeaseTest, triple_node) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
     for (int i = 0; i < 3; i++) {
@@ -219,7 +236,7 @@ TEST_F(LeaseTest, triple_node) {
     cluster.stop_all();
 }
 
-TEST_F(LeaseTest, change_peers) {
+TEST_F(BaseLeaseTest, change_peers) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
     braft::PeerId peer0;
@@ -279,10 +296,10 @@ TEST_F(LeaseTest, change_peers) {
     cluster.stop_all();
 }
 
-TEST_F(LeaseTest, transfer_leadership_success) {
+TEST_P(ExtendLeaseTest, transfer_leadership_success) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -329,10 +346,10 @@ TEST_F(LeaseTest, transfer_leadership_success) {
     cluster.stop_all();
 }
 
-TEST_F(LeaseTest, transfer_leadership_timeout) {
+TEST_P(ExtendLeaseTest, transfer_leadership_timeout) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -375,10 +392,10 @@ TEST_F(LeaseTest, transfer_leadership_timeout) {
     cluster.stop_all();
 }
 
-TEST_F(LeaseTest, vote) {
+TEST_P(ExtendLeaseTest, vote) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -431,10 +448,10 @@ TEST_F(LeaseTest, vote) {
     cluster.stop_all();
 }
 
-TEST_F(LeaseTest, leader_step_down) {
+TEST_P(ExtendLeaseTest, leader_step_down) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> peers;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -456,8 +473,9 @@ TEST_F(LeaseTest, leader_step_down) {
     cluster.followers(&nodes);
 
     braft::SynchronizedClosure done;
-    static_cast<MockFSM*>(nodes[0]->_impl->_options.fsm)->set_on_leader_start_closure(&done);
-    static_cast<MockFSM*>(nodes[1]->_impl->_options.fsm)->set_on_leader_start_closure(&done);
+    for (int i = 0; i < peer_num - 1; ++i) {
+        static_cast<MockFSM*>(nodes[i]->_impl->_options.fsm)->set_on_leader_start_closure(&done);
+    }
 
     int64_t begin_ms = butil::monotonic_time_ms();
     cluster.stop(leader->node_id().peer_id.addr);
@@ -492,12 +510,12 @@ public:
     butil::atomic<bool> running;
 };
 
-TEST_F(LeaseTest, apply_thread_hung) {
+TEST_P(ExtendLeaseTest, apply_thread_hung) {
     ::system("rm -rf data");
     braft::LeaderLeaseStatus lease_status;
     std::vector<braft::PeerId> peers;
     std::vector<OnLeaderStartHungClosure*> on_leader_start_closures;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -557,10 +575,10 @@ TEST_F(LeaseTest, apply_thread_hung) {
     }
 }
 
-TEST_F(LeaseTest, chaos) {
+TEST_P(ExtendLeaseTest, chaos) {
     ::system("rm -rf data");
     std::vector<braft::PeerId> started_nodes;
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < peer_num; i++) {
         braft::PeerId peer;
         peer.addr.ip = butil::my_ip();
         peer.addr.port = 5006 + i;
@@ -588,7 +606,7 @@ TEST_F(LeaseTest, chaos) {
     };
 
     std::vector<braft::PeerId> stopped_nodes;
-    for (size_t i = 0; i < 500; ++i) {
+    for (size_t i = 0; i < 100; ++i) {
         OpType type = static_cast<OpType>(butil::fast_rand() % OP_END);
         if (type == NODE_START) {
             if (stopped_nodes.empty()) {
@@ -673,3 +691,5 @@ TEST_F(LeaseTest, chaos) {
 
     cluster.stop_all();
 }
+
+INSTANTIATE_TEST_CASE_P(ExtendLeaseTest, ExtendLeaseTest, ::testing::Values(3, 5));

--- a/test/util.h
+++ b/test/util.h
@@ -68,7 +68,9 @@ public:
     void on_leader_start(int64_t term) {
         _leader_term = term;
         if (_on_leader_start_closure) {
+            LOG(NOTICE) << "addr " << address << " before leader start closure";
             _on_leader_start_closure->Run();
+            LOG(NOTICE) << "addr " << address << " after leader start closure";
             _on_leader_start_closure = NULL;
         }
     }


### PR DESCRIPTION
Here is an example:

- A Raft group has five peers, {peer_a, peer_b, peer_c, peer_d, peer_e}, and peer_a is the current leader;

- Transfer leader from peer_a to peer_b;

- After peer_b catch up all logs, peer_a send TimeoutNowRequest to peer_b;

- peer_b become the candidate, and ask for other peers to vote;

- peer_a step down, vote peer_b, but peer_c, peer_d, peer_e reject peer_b since the follower lease is still valid;

- peer_b can't get enough ballots.

The solution is that, if a candidate get the vote of last leader, expire the follower lease.