### PR TITLE
fix report_error 

### DIFF
--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -939,7 +939,7 @@ void LogManager::report_error(int error_code, const char* fmt, ...) {
     va_start(ap, fmt);
     Error e;
     e.set_type(ERROR_TYPE_LOG);
-    e.status().set_error(error_code, fmt, ap);
+    e.status().set_errorv(error_code, fmt, ap);
     va_end(ap);
     _fsm_caller->on_error(e);
 }


### PR DESCRIPTION
I modify some braft code by mistake and report error, the index value in error_text is illegal as result of using set_error instead of set_errorv in LogManager::report_error

error={type=LogError, error_code=5, error_text=`Corrupted entry at index=49248153193352'}