### PR TITLE
reduce election time cost for brand new cluster when leader lease enabled

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -556,6 +556,10 @@ int NodeImpl::init(const NodeOptions& options) {
                    << " init_meta_storage failed";
         return -1;
     }
+    // first start, we can vote directly
+    if (_current_term == 1 && _voted_id.is_empty()) {
+        _follower_lease.reset();
+    }
 
     // init replicator
     ReplicatorGroupOptions rg_options;


### PR DESCRIPTION
When leader lease enabled, each node has to wait follower lease expire(about an election timeout) before it can vote.
It's necessary for an exsitsing raft group to prevent split brain.

But it's not necessary for a brand new cluster.

The definition of **brand new cluster** is `_term == 1 && _voted_id.empty()`, which means that the node has never `elect_self` and has never received an RPC with higher term and has never voted.