### PR TITLE
check peer's _consecutive_error_times before start transfering leader

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1180,6 +1180,12 @@ int NodeImpl::transfer_leadership_to(const PeerId& peer) {
     const int64_t last_log_index = _log_manager->last_log_index();
     const int rc = _replicator_group.transfer_leadership_to(peer_id, last_log_index);
     if (rc != 0) {
+        if (rc == -2) {
+            LOG(WARNING) << "peer: " << peer_id
+                    << " _consecutive_error_times not 0"
+                    << " peer maybe dead";
+            return EFAULT;
+        }
         LOG(WARNING) << "node " << _group_id << ":" << _server_id
                      << " fail to transfer leadership, no such peer=" << peer_id;
         return EINVAL;

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1041,6 +1041,11 @@ int Replicator::stop_transfer_leadership(ReplicatorId id) {
 }
 
 int Replicator::_transfer_leadership(int64_t log_index) {
+    // peer might be dead, stop transfer leadership
+    if (_consecutive_error_times != 0) { 
+        CHECK_EQ(0, bthread_id_unlock(_id)) << "Fail to unlock " << _id;
+        return -2;
+    }
     if (_has_succeeded && _min_flying_index() > log_index) {
         // _id is unlock in _send_timeout_now
         _send_timeout_now(true, false);

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1846,13 +1846,13 @@ TEST_P(NodeTest, leader_transfer_before_log_is_compleleted) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(0, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
     data.resize(5, 'a');
     task.data = &data;
-    task.done = NEW_APPLYCLOSURE(&cond, EBUSY);
+    task.done = NEW_APPLYCLOSURE(&cond, 0);
     leader->apply(task);
     cond.wait();
     cluster.start(target.addr);
@@ -1903,14 +1903,14 @@ TEST_P(NodeTest, leader_transfer_resume_on_failure) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(0, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
     braft::Node* saved_leader = leader;
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
     data.resize(5, 'a');
     task.data = &data;
-    task.done = NEW_APPLYCLOSURE(&cond, EBUSY);
+    task.done = NEW_APPLYCLOSURE(&cond, 0);
     leader->apply(task);
     cond.wait();
     //cluster.start(target.addr);


### PR DESCRIPTION
#264 