### PR TITLE
check peer's _consecutive_error_times before start transfering leader

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1180,6 +1180,12 @@ int NodeImpl::transfer_leadership_to(const PeerId& peer) {
     const int64_t last_log_index = _log_manager->last_log_index();
     const int rc = _replicator_group.transfer_leadership_to(peer_id, last_log_index);
     if (rc != 0) {
+        if (rc == -2) {
+            LOG(WARNING) << "peer: " << peer_id
+                    << " _consecutive_error_times not 0"
+                    << " peer maybe dead";
+            return EFAULT;
+        }
         LOG(WARNING) << "node " << _group_id << ":" << _server_id
                      << " fail to transfer leadership, no such peer=" << peer_id;
         return EINVAL;

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1041,6 +1041,11 @@ int Replicator::stop_transfer_leadership(ReplicatorId id) {
 }
 
 int Replicator::_transfer_leadership(int64_t log_index) {
+    // peer might be dead, stop transfer leadership
+    if (_consecutive_error_times != 0) { 
+        CHECK_EQ(0, bthread_id_unlock(_id)) << "Fail to unlock " << _id;
+        return -2;
+    }
     if (_has_succeeded && _min_flying_index() > log_index) {
         // _id is unlock in _send_timeout_now
         _send_timeout_now(true, false);

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1041,7 +1041,7 @@ int Replicator::stop_transfer_leadership(ReplicatorId id) {
 }
 
 int Replicator::_transfer_leadership(int64_t log_index) {
-    // peer might be dead, stop transfer leadership
+    // peer might be dead, stop to transfer leadership
     if (_consecutive_error_times != 0) { 
         CHECK_EQ(0, bthread_id_unlock(_id)) << "Fail to unlock " << _id;
         return -2;

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1458,19 +1458,14 @@ int ReplicatorGroup::transfer_leadership_to(
         const PeerId& peer, int64_t log_index) {
     std::map<PeerId, ReplicatorIdAndStatus>::const_iterator iter = _rmap.find(peer);
     if (iter == _rmap.end()) {
-        return -1;
+        return EINVAL;
     }
     ReplicatorId rid = iter->second.id;
+    const int consecutive_error_times = Replicator::get_consecutive_error_times(rid);
+    if (consecutive_error_times > 0) {
+        return EHOSTUNREACH;
+    }
     return Replicator::transfer_leadership(rid, log_index);
-}
-
-int ReplicatorGroup::get_consecutive_error_times(const PeerId& peer) {
-    std::map<PeerId, ReplicatorIdAndStatus>::const_iterator iter = _rmap.find(peer);
-    if (iter == _rmap.end()) {
-        return -1;
-    }
-    ReplicatorId rid = iter->second.id;
-    return Replicator::get_consecutive_error_times(rid);
 }
 
 int ReplicatorGroup::stop_transfer_leadership(const PeerId& peer) {

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1188,7 +1188,7 @@ int Replicator::get_consecutive_error_times(ReplicatorId id) {
     if (bthread_id_lock(dummy_id, (void**)&r) != 0) {
         return -1;
     }
-    int64_t consecutive_error_times = r->_consecutive_error_times;
+    int consecutive_error_times = r->_consecutive_error_times;
     CHECK_EQ(0, bthread_id_unlock(dummy_id)) << "Fail to unlock " << dummy_id;
     return consecutive_error_times;
 }

--- a/src/braft/replicator.h
+++ b/src/braft/replicator.h
@@ -326,10 +326,6 @@ public:
     // Transfer leadership to the given |peer|
     int transfer_leadership_to(const PeerId& peer, int64_t log_index);
 
-    // Get consecutive error times of the given |peer|
-    // Return the correct value on success, -1 otherwise
-    int get_consecutive_error_times(const PeerId& peer);
-
     // Stop transferring leadership to the given |peer|
     int stop_transfer_leadership(const PeerId& peer);
 

--- a/src/braft/replicator.h
+++ b/src/braft/replicator.h
@@ -112,6 +112,10 @@ public:
     // Return the correct value on success, 0 otherwise.
     static int64_t get_next_index(ReplicatorId id);
 
+    // Get the consecutive error times of this Replica
+    // Return the correct value on success, -1 otherwise.
+    static int get_consecutive_error_times(ReplicatorId id);
+
     static void describe(ReplicatorId id, std::ostream& os, bool use_html);
 
     // Get replicator internal status.
@@ -321,6 +325,10 @@ public:
 
     // Transfer leadership to the given |peer|
     int transfer_leadership_to(const PeerId& peer, int64_t log_index);
+
+    // Get consecutive error times of the given |peer|
+    // Return the correct value on success, -1 otherwise
+    int get_consecutive_error_times(const PeerId& peer);
 
     // Stop transferring leadership to the given |peer|
     int stop_transfer_leadership(const PeerId& peer);

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1846,13 +1846,13 @@ TEST_P(NodeTest, leader_transfer_before_log_is_compleleted) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(0, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
     data.resize(5, 'a');
     task.data = &data;
-    task.done = NEW_APPLYCLOSURE(&cond, EBUSY);
+    task.done = NEW_APPLYCLOSURE(&cond, 0);
     leader->apply(task);
     cond.wait();
     cluster.start(target.addr);
@@ -1903,14 +1903,14 @@ TEST_P(NodeTest, leader_transfer_resume_on_failure) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(0, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
     braft::Node* saved_leader = leader;
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
     data.resize(5, 'a');
     task.data = &data;
-    task.done = NEW_APPLYCLOSURE(&cond, EBUSY);
+    task.done = NEW_APPLYCLOSURE(&cond, 0);
     leader->apply(task);
     cond.wait();
     //cluster.start(target.addr);

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1846,7 +1846,7 @@ TEST_P(NodeTest, leader_transfer_before_log_is_compleleted) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(-1, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EHOSTUNREACH, leader->transfer_leadership_to(target));
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
@@ -1904,7 +1904,7 @@ TEST_P(NodeTest, leader_transfer_resume_on_failure) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(-1, leader->transfer_leadership_to(target));
+    ASSERT_EQ(EHOSTUNREACH, leader->transfer_leadership_to(target));
     braft::Node* saved_leader = leader;
     cond.reset(1);
     braft::Task task;

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1846,7 +1846,7 @@ TEST_P(NodeTest, leader_transfer_before_log_is_compleleted) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
+    ASSERT_EQ(-1, leader->transfer_leadership_to(target));
     cond.reset(1);
     braft::Task task;
     butil::IOBuf data;
@@ -1904,7 +1904,7 @@ TEST_P(NodeTest, leader_transfer_resume_on_failure) {
         leader->apply(task);
     }
     cond.wait();
-    ASSERT_EQ(EFAULT, leader->transfer_leadership_to(target));
+    ASSERT_EQ(-1, leader->transfer_leadership_to(target));
     braft::Node* saved_leader = leader;
     cond.reset(1);
     braft::Task task;

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1855,12 +1855,13 @@ TEST_P(NodeTest, leader_transfer_before_log_is_compleleted) {
     task.done = NEW_APPLYCLOSURE(&cond, 0);
     leader->apply(task);
     cond.wait();
+    braft::Node* saved_leader = leader;
     cluster.start(target.addr);
     usleep(5000 * 1000);
     LOG(INFO) << "here";
     cluster.wait_leader();
     leader = cluster.leader();
-    ASSERT_EQ(target, leader->node_id().peer_id);
+    ASSERT_EQ(saved_leader->node_id().peer_id, leader->node_id().peer_id);
     ASSERT_TRUE(cluster.ensure_same(5));
     cluster.stop_all();
 }


### PR DESCRIPTION
如果业务主动让leader transfer_leader到一个可能已经宕机的peer的时候（业务不知道peer dead），这时候在一个election_timeout的时间内会无主，通过replicator的_consecutive_error_times来判断如果peer dead，transfer_leader的时候就不要变成STATE_TRANSFERRING了，而是直接返回transfer_leader失败，让业务去重试，这样就不会有一个election_timeout的时间内无主
#264 