### PR TITLE
Add PositiveInteger validate to raft_election_heartbeat_factor

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -123,6 +123,7 @@ inline int random_timeout(int timeout_ms) {
 }
 
 DEFINE_int32(raft_election_heartbeat_factor, 10, "raft election:heartbeat timeout factor");
+BRPC_VALIDATE_GFLAG(raft_election_heartbeat_factor, brpc::PositiveInteger);
 static inline int heartbeat_timeout(int election_timeout) {
     return std::max(election_timeout / FLAGS_raft_election_heartbeat_factor, 10);
 }


### PR DESCRIPTION
If set `raft_election_heartbeat_factor` to zero,
https://github.com/baidu/braft/blob/979da559b9c1e1b1b57cfc68c6c18f577aeb878e/src/braft/node.cpp#L127
here will raise floating point exception.

So, we need add `PositiveInteger` validate to `raft_election_heartbeat_factor`.