### PR TITLE
Erase last_segment from _segment when it transform into open_segment

### DIFF
--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -927,6 +927,7 @@ int SegmentLogStorage::truncate_suffix(const int64_t last_index_kept) {
         if (ret == 0 && closed && last_segment->is_open()) {
             BAIDU_SCOPED_LOCK(_mutex);
             CHECK(!_open_segment);
+            _segments.erase(last_segment->first_index());
             _open_segment.swap(last_segment);
         }
     }

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -209,7 +209,7 @@ private:
             int64_t first_index_kept, 
             std::vector<scoped_refptr<Segment> >* poped);
     void pop_segments_from_back(
-            const int64_t first_index_kept,
+            const int64_t last_index_kept,
             std::vector<scoped_refptr<Segment> >* popped,
             scoped_refptr<Segment>* last_segment);
 

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -352,7 +352,7 @@ TEST_F(LogStorageTest, multi_segment_and_segment_logstorage) {
         ASSERT_EQ(5, storage->append_entries(entries, NULL));
 
         for (size_t j = 0; j < entries.size(); j++) {
-            delete entries[j];
+            entries[j]->Release();
         }
     }
 
@@ -371,7 +371,7 @@ TEST_F(LogStorageTest, multi_segment_and_segment_logstorage) {
             storage->truncate_suffix(first_seg->last_index() + 1);
         }
         braft::SegmentLogStorage::SegmentMap& segments2 = storage->segments();
-        ASSERT_EQ(2ul, segments2.size());
+        ASSERT_EQ(1ul, segments2.size());
         ASSERT_EQ(storage->last_log_index(), first_seg->last_index() + 1);
         storage->truncate_suffix(first_seg->last_index());
         braft::SegmentLogStorage::SegmentMap& segments3 = storage->segments();


### PR DESCRIPTION
After truncating suffix log, a `last_segment` that exists in `_segments` maybe change from `closed` to `open`,  so it would erase from `_segments`. Or it will be deleted twice when `SegmentLogStorage::reset` call.

https://github.com/baidu/braft/blob/154d805bd1eb88df97121fe1c73a5b469df88056/test/test_log.cpp#L374

In `multi_segment_and_segment_logstorage` unit test, after truncating suffix log at `first_seg->last_index() + 1`, last_segment at the second to last of the `_segments` which is closed, when it transform into open, it would erase from `_segments`.
https://github.com/baidu/braft/blob/154d805bd1eb88df97121fe1c73a5b469df88056/src/braft/log.cpp#L927