### PR TITLE
enable linearizable reads

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -3431,6 +3431,14 @@ void NodeImpl::get_leader_lease_status(LeaderLeaseStatus* lease_status) {
     }
 }
 
+int64_t NodeImpl::last_committed_index() {
+    return _ballot_box->last_committed_index();
+}
+
+bool NodeImpl::can_linearizable_read(int64_t readindex) {
+    return FLAGS_raft_enable_leader_lease && is_leader_lease_valid() && (_fsm_caller->last_applied_index() >= readindex);
+}
+
 void NodeImpl::VoteBallotCtx::init(NodeImpl* node, bool triggered) {
     reset(node);
     _ballot.init(node->_conf.conf, node->_conf.stable() ? NULL : &(node->_conf.old_conf));

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -226,6 +226,9 @@ public:
     bool is_leader_lease_valid();
     void get_leader_lease_status(LeaderLeaseStatus* status);
 
+    int64_t last_committed_index();
+    bool can_linearizable_read(int64_t readindex);
+
     // Call on_error when some error happens, after this is called.
     // After this point:
     //  - This node is to step down immediately if it was the leader.

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -166,6 +166,14 @@ void Node::get_leader_lease_status(LeaderLeaseStatus* status) {
     return _impl->get_leader_lease_status(status);
 }
 
+int64_t Node::last_committed_index() {
+    return _impl->last_committed_index();
+}
+
+bool Node::can_linearizable_read(int64_t readindex) {
+    return _impl->can_linearizable_read(readindex);
+}
+
 int Node::init(const NodeOptions& options) {
     return _impl->init(options);
 }

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -642,6 +642,13 @@ public:
     // Get leader lease status for more complex checking
     void get_leader_lease_status(LeaderLeaseStatus* status);
 
+    // Get last committed log index
+    int64_t last_committed_index();
+
+    // Return true if read would not get stale value
+    // readindex is the saved value of last_committed_index() before read
+    bool can_linearizable_read(int64_t readindex);
+
     // init node
     int init(const NodeOptions& options);
 


### PR DESCRIPTION
To support linearizable reads, the description at https://github.com/baidu/braft/issues/238 is not enough, it needs to make sure applied_index not less than saved last_committed_index before reads. This commit provides interfaces to enable linearizable reads