### PR TITLE
to #313: add bootstrap option: set snapshot configuration instead of …

### DIFF
--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -319,6 +319,7 @@ BootstrapOptions::BootstrapOptions()
     , fsm(NULL)
     , node_owns_fsm(false)
     , usercode_in_pthread(false)
+    , set_snapshot_configuration(false)
 {}
 
 int bootstrap(const BootstrapOptions& options) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -804,6 +804,10 @@ struct BootstrapOptions {
     // Default: false
     bool usercode_in_pthread;
 
+    // Set configuration to snapshot instead of adding configuration log
+    // Default: false
+    bool set_snapshot_configuration;
+
     // Describe a specific LogStorage in format ${type}://${parameters}
     std::string log_uri;
 


### PR DESCRIPTION
#313  提供bootstrap选项直接设置snapshot中的conf peers， 而不是通过写一条新的configuration conf， 这样可以避免index的增加导致的数据不一致的情况，应用层也多了一种选择