### PR TITLE
raft arbiter support

### DIFF
--- a/src/braft/fsm_caller.cpp
+++ b/src/braft/fsm_caller.cpp
@@ -298,7 +298,12 @@ void FSMCaller::do_committed(int64_t committed_index) {
             continue;
         }
         Iterator iter(&iter_impl);
-        _fsm->on_apply(iter);
+        if (!_node->arbiter()) {
+            _fsm->on_apply(iter);
+        } else {
+            for (;iter.valid();iter.next()) {
+            }
+        }
         LOG_IF(ERROR, iter.valid())
                 << "Node " << _node->node_id() 
                 << " Iterator is still valid, did you return before iterator "
@@ -353,7 +358,11 @@ void FSMCaller::do_snapshot_save(SaveSnapshotClosure* done) {
         return;
     }
 
-    _fsm->on_snapshot_save(writer, done);
+    if (!_node->arbiter()) {
+        _fsm->on_snapshot_save(writer, done);
+    } else {
+       done->Run();
+    }
     return;
 }
 
@@ -402,7 +411,9 @@ void FSMCaller::do_snapshot_load(LoadSnapshotClosure* done) {
         return done->Run();
     }
 
-    ret = _fsm->on_snapshot_load(reader);
+    if (!_node->arbiter()) {
+        ret = _fsm->on_snapshot_load(reader);
+    }
     if (ret != 0) {
         done->status().set_error(ret, "StateMachine on_snapshot_load failed");
         done->Run();

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1039,6 +1039,11 @@ void NodeImpl::handle_election_timeout() {
 
         return;
     }
+
+    if (arbiter()) {
+        return;
+    }
+
     bool triggered = _vote_triggered;
     _vote_triggered = false;
 
@@ -1084,6 +1089,12 @@ void NodeImpl::handle_timeout_now_request(brpc::Controller* controller,
         LOG(INFO) << "node " << _group_id << ":" << _server_id
                   << " received handle_timeout_now_request while state is " 
                   << state2str(saved_state) << " at term=" << saved_term;
+        return;
+    }
+    if (arbiter()) {
+        response->set_term(_current_term);
+        response->set_success(false);
+        lck.unlock();
         return;
     }
     const butil::EndPoint remote_side = controller->remote_side();
@@ -2698,7 +2709,7 @@ void NodeImpl::describe(std::ostream& os, bool use_html) {
     lck.unlock();
     const char *newline = use_html ? "<br>" : "\r\n";
     os << "peer_id: " << _server_id << newline;
-    os << "state: " << state2str(st) << newline;
+    os << "state: " << state2str(st) << (arbiter() ? ", ARBITER" : "") << newline;
     os << "readonly: " << readonly << newline;
     os << "term: " << term << newline;
     os << "conf_index: " << conf_index << newline;

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -241,6 +241,8 @@ public:
 
     bool disable_cli() const { return _options.disable_cli; }
 
+    bool arbiter() const { return _options.arbiter; }
+
 private:
 friend class butil::RefCountedThreadSafe<NodeImpl>;
 

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -588,6 +588,8 @@ struct NodeOptions {
     // Default: false
     bool disable_cli;
 
+    bool arbiter;
+
     // Construct a default instance
     NodeOptions();
 
@@ -609,6 +611,7 @@ inline NodeOptions::NodeOptions()
     , snapshot_file_system_adaptor(NULL)
     , snapshot_throttle(NULL)
     , disable_cli(false)
+    , arbiter(false)
 {}
 
 inline int NodeOptions::get_catchup_timeout_ms() {

--- a/src/braft/snapshot_executor.cpp
+++ b/src/braft/snapshot_executor.cpp
@@ -364,6 +364,9 @@ int SnapshotExecutor::init(const SnapshotExecutorOptions& options) {
         _snapshot_throttle = options.snapshot_throttle;
         _snapshot_storage->set_snapshot_throttle(options.snapshot_throttle);
     }
+    if (_node->arbiter()) {
+        _snapshot_storage->dummy = true;
+    }
     if (_snapshot_storage->init() != 0) {
         LOG(ERROR) << "node " << _node->node_id() 
                    << " fail to init snapshot storage, uri " << options.uri;

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -354,6 +354,7 @@ public:
     }
 
     static butil::Status destroy(const std::string& uri);
+    bool dummy = false;
 };
 
 inline brpc::Extension<const LogStorage>* log_storage_extension() {


### PR DESCRIPTION
This commit implements raft arbiter. An arbiter does not have a copy of data and only participates in elections. The concept is similar to MongoDB arbiter (https://docs.mongodb.com/manual/core/replica-set-arbiter). The motivation behind is for some cost-sensitive circumstances, three copies are not affordable, but an odd number of votes are needed to break a tie