### PR TITLE
add raft_sync_per_bytes flag

### DIFF
--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -551,5 +551,5 @@ raft中有很多flags配置项，运行中可以通过http://endpoint/flags 查�
 | raft_max_byte_count_per_rpc    | snapshot每次rpc下载大小          |
 | raft_apply_batch               | apply的时候最大batch数量          |
 | raft_election_heartbeat_factor | election超时与heartbeat超时的比例  |
-| raft_sync_policy               | raft_sync为true时的细化策略，0表示直接进行sync，1表示每写入bytes才进行sync |
+| raft_sync_policy               | raft_sync为true时的细化策略，0表示每次写都立即sync，1表示每写入多少bytes才进行一次sync |
 | raft_sync_per_bytes            | raft_sync_policy 为1 时生效,表示每写bytes进行sync |

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -551,3 +551,5 @@ raft中有很多flags配置项，运行中可以通过http://endpoint/flags 查�
 | raft_max_byte_count_per_rpc    | snapshot每次rpc下载大小          |
 | raft_apply_batch               | apply的时候最大batch数量          |
 | raft_election_heartbeat_factor | election超时与heartbeat超时的比例  |
+| raft_sync_policy               | raft_sync为false时的sync策略，0表示永远不主动进行sync，1表示每写入bytes进行sync |
+| raft_sync_per_bytes            | raft_sync_policy 为1 时生效,表示每写bytes进行sync |

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -551,5 +551,5 @@ raft中有很多flags配置项，运行中可以通过http://endpoint/flags 查�
 | raft_max_byte_count_per_rpc    | snapshot每次rpc下载大小          |
 | raft_apply_batch               | apply的时候最大batch数量          |
 | raft_election_heartbeat_factor | election超时与heartbeat超时的比例  |
-| raft_sync_policy               | raft_sync为false时的sync策略，0表示永远不主动进行sync，1表示每写入bytes进行sync |
+| raft_sync_policy               | raft_sync为true时的细化策略，0表示直接进行sync，1表示每写入bytes才进行sync |
 | raft_sync_per_bytes            | raft_sync_policy 为1 时生效,表示每写bytes进行sync |

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -442,14 +442,15 @@ int Segment::sync(bool will_sync) {
     }
     //CHECK(_is_open);
     if (will_sync) {
-        if (FLAGS_raft_sync) {
-            return raft_fsync(_fd);
+        if (!FLAGS_raft_sync) {
+            return 0;
         }
         if (FLAGS_raft_sync_policy == RaftSyncPolicy::RAFT_SYNC_BY_BYTES
-            && FLAGS_raft_sync_per_bytes < _unsynced_bytes) {
-            _unsynced_bytes = 0;
-            return raft_fsync(_fd);
+            && FLAGS_raft_sync_per_bytes > _unsynced_bytes) {
+            return 0;
         }
+        _unsynced_bytes = 0;
+        return raft_fsync(_fd);
     }
     return 0;
 }

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -434,12 +434,12 @@ int Segment::sync(bool will_sync) {
     if (_last_index > _first_index) {
         //CHECK(_is_open);
         if (will_sync) {
-          if (FLAGS_raft_sync) {
-            return raft_fsync(_fd);
-          }  else if (FLAGS_raft_sync_per_bytes < _unsynced_bytes)  {
-            _unsynced_bytes = 0;
-            return raft_fsync(_fd);
-          }
+            if (FLAGS_raft_sync) {
+                return raft_fsync(_fd);
+            } else if (FLAGS_raft_sync_per_bytes < _unsynced_bytes)  {
+                _unsynced_bytes = 0;
+                return raft_fsync(_fd);
+            }
         }
         return 0;
     } else {

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -70,7 +70,7 @@ enum CheckSumType {
 };
 
 enum RaftSyncPolicy {
-    RAFT_SYNC_NEVER = 0,
+    RAFT_SYNC_IMMEDIATELY = 0,
     RAFT_SYNC_BY_BYTES = 1,
 };
 

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -70,9 +70,10 @@ enum CheckSumType {
 };
 
 enum RaftSyncPolicy {
-    RAFT_SYNC_NOHTING = 0,
+    RAFT_SYNC_NEVER = 0,
     RAFT_SYNC_BY_BYTES = 1,
 };
+
 
 // Format of Header, all fields are in network order
 // | -------------------- term (64bits) -------------------------  |

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -35,14 +35,14 @@ class BAIDU_CACHELINE_ALIGNMENT Segment
         : public butil::RefCountedThreadSafe<Segment> {
 public:
     Segment(const std::string& path, const int64_t first_index, int checksum_type)
-        : _path(path), _bytes(0),_unsynced_bytes(0),
+        : _path(path), _bytes(0), _unsynced_bytes(0),
         _fd(-1), _is_open(true),
         _first_index(first_index), _last_index(first_index - 1),
         _checksum_type(checksum_type)
     {}
     Segment(const std::string& path, const int64_t first_index, const int64_t last_index,
             int checksum_type)
-        : _path(path), _bytes(0),_unsynced_bytes(0),
+        : _path(path), _bytes(0), _unsynced_bytes(0),
         _fd(-1), _is_open(false),
         _first_index(first_index), _last_index(last_index),
         _checksum_type(checksum_type)

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -35,14 +35,14 @@ class BAIDU_CACHELINE_ALIGNMENT Segment
         : public butil::RefCountedThreadSafe<Segment> {
 public:
     Segment(const std::string& path, const int64_t first_index, int checksum_type)
-        : _path(path), _bytes(0),
+        : _path(path), _bytes(0),_unsynced_bytes(0),
         _fd(-1), _is_open(true),
         _first_index(first_index), _last_index(first_index - 1),
         _checksum_type(checksum_type)
     {}
     Segment(const std::string& path, const int64_t first_index, const int64_t last_index,
             int checksum_type)
-        : _path(path), _bytes(0),
+        : _path(path), _bytes(0),_unsynced_bytes(0),
         _fd(-1), _is_open(false),
         _first_index(first_index), _last_index(last_index),
         _checksum_type(checksum_type)
@@ -119,6 +119,7 @@ friend class butil::RefCountedThreadSafe<Segment>;
 
     std::string _path;
     int64_t _bytes;
+    int64_t _unsynced_bytes;
     mutable raft_mutex_t _mutex;
     int _fd;
     bool _is_open;

--- a/src/braft/storage.cpp
+++ b/src/braft/storage.cpp
@@ -34,7 +34,9 @@ DEFINE_int32(raft_sync_per_bytes, INT32_MAX,
              "sync raft log per bytes when raft_sync set to false");
 DEFINE_bool(raft_create_parent_directories, true,
             "Create parent directories of the path in local storage if true");
-DEFINE_int32(raft_sync_policy, 0, "raft sync policy when raft_sync set to false");
+DEFINE_int32(raft_sync_policy, 0,
+             "raft sync policy when raft_sync set to false, 0 mean never sync, 1 mean sync by "
+             "writed bytes");
 DEFINE_bool(raft_sync_meta, false, "sync log meta, snapshot meta and raft meta");
 BRPC_VALIDATE_GFLAG(raft_sync_meta, ::brpc::PassValidate);
 BRPC_VALIDATE_GFLAG(raft_sync_per_bytes, ::brpc::NonNegativeInteger);

--- a/src/braft/storage.cpp
+++ b/src/braft/storage.cpp
@@ -34,7 +34,7 @@ DEFINE_int32(raft_sync_per_bytes, INT32_MAX,
              "sync raft log per bytes when raft_sync set to false");
 DEFINE_bool(raft_create_parent_directories, true,
             "Create parent directories of the path in local storage if true");
-
+DEFINE_int32(raft_sync_policy, 0, "raft sync policy when raft_sync set to false");
 DEFINE_bool(raft_sync_meta, false, "sync log meta, snapshot meta and raft meta");
 BRPC_VALIDATE_GFLAG(raft_sync_meta, ::brpc::PassValidate);
 BRPC_VALIDATE_GFLAG(raft_sync_per_bytes, ::brpc::NonNegativeInteger);

--- a/src/braft/storage.cpp
+++ b/src/braft/storage.cpp
@@ -30,11 +30,14 @@ namespace braft {
 
 DEFINE_bool(raft_sync, true, "call fsync when need");
 BRPC_VALIDATE_GFLAG(raft_sync, ::brpc::PassValidate);
+DEFINE_int32(raft_sync_per_bytes, INT32_MAX,
+             "sync raft log per bytes when raft_sync set to false");
 DEFINE_bool(raft_create_parent_directories, true,
             "Create parent directories of the path in local storage if true");
 
 DEFINE_bool(raft_sync_meta, false, "sync log meta, snapshot meta and raft meta");
 BRPC_VALIDATE_GFLAG(raft_sync_meta, ::brpc::PassValidate);
+BRPC_VALIDATE_GFLAG(raft_sync_per_bytes, ::brpc::NonNegativeInteger);
 
 LogStorage* LogStorage::create(const std::string& uri) {
     butil::StringPiece copied_uri(uri);

--- a/src/braft/storage.cpp
+++ b/src/braft/storage.cpp
@@ -31,7 +31,8 @@ namespace braft {
 DEFINE_bool(raft_sync, true, "call fsync when need");
 BRPC_VALIDATE_GFLAG(raft_sync, ::brpc::PassValidate);
 DEFINE_int32(raft_sync_per_bytes, INT32_MAX,
-             "sync raft log per bytes when raft_sync set to false");
+             "sync raft log per bytes when raft_sync set to true");
+BRPC_VALIDATE_GFLAG(raft_sync_per_bytes, ::brpc::NonNegativeInteger);
 DEFINE_bool(raft_create_parent_directories, true,
             "Create parent directories of the path in local storage if true");
 DEFINE_int32(raft_sync_policy, 0,
@@ -39,7 +40,6 @@ DEFINE_int32(raft_sync_policy, 0,
              "writed bytes");
 DEFINE_bool(raft_sync_meta, false, "sync log meta, snapshot meta and raft meta");
 BRPC_VALIDATE_GFLAG(raft_sync_meta, ::brpc::PassValidate);
-BRPC_VALIDATE_GFLAG(raft_sync_per_bytes, ::brpc::NonNegativeInteger);
 
 LogStorage* LogStorage::create(const std::string& uri) {
     butil::StringPiece copied_uri(uri);

--- a/src/braft/storage.cpp
+++ b/src/braft/storage.cpp
@@ -35,7 +35,7 @@ DEFINE_int32(raft_sync_per_bytes, INT32_MAX,
 DEFINE_bool(raft_create_parent_directories, true,
             "Create parent directories of the path in local storage if true");
 DEFINE_int32(raft_sync_policy, 0,
-             "raft sync policy when raft_sync set to false, 0 mean never sync, 1 mean sync by "
+             "raft sync policy when raft_sync set to true, 0 mean sync immediately, 1 mean sync by "
              "writed bytes");
 DEFINE_bool(raft_sync_meta, false, "sync log meta, snapshot meta and raft meta");
 BRPC_VALIDATE_GFLAG(raft_sync_meta, ::brpc::PassValidate);

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -39,6 +39,7 @@ namespace braft {
 DECLARE_bool(raft_sync);
 DECLARE_bool(raft_sync_meta);
 DECLARE_int32(raft_sync_per_bytes);
+DECLARE_int32(raft_sync_policy);
 DECLARE_bool(raft_create_parent_directories);
 
 struct LogEntry;

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -38,6 +38,7 @@ namespace braft {
 
 DECLARE_bool(raft_sync);
 DECLARE_bool(raft_sync_meta);
+DECLARE_int32(raft_sync_per_bytes);
 DECLARE_bool(raft_create_parent_directories);
 
 struct LogEntry;


### PR DESCRIPTION
添加raft_sync_per_bytes用于及时刷新page cache到磁盘，通常在吞吐高以及在对数据一致性要求不是非常高的场景下可以关闭raft_sync， 但是当吞吐高的时候如果关闭了raft_sync， 当脏页比例超过dirty_ratio时，会导致进程卡住等待flush 脏页引起抖动，通过设置raft_sync_per_bytes 一方面可以避免写入刷脏页抖动，另一方面可以减少宕机情况下可能丢失的数据。