### PR TITLE
Ignore prevote if leader lease is still valid.

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -2088,8 +2088,8 @@ int NodeImpl::handle_pre_vote_request(const RequestVoteRequest* request,
     bool granted = false;
     bool rejected_by_lease = false;
     do {
-        if (request->term() < _current_term) {
-            // ignore older term
+        if (is_leader_lease_valid() || request->term() < _current_term) {
+            // ignore older term or the leader lease is still valid.
             LOG(INFO) << "node " << _group_id << ":" << _server_id
                       << " ignore PreVote from " << request->server_id()
                       << " in term " << request->term()


### PR DESCRIPTION
Suppose a raft group ng0 consists of three nodes(A(localhost:8001),
B(localhost:8011), C(localhost:8021)), timeline is as follows: T1: A is elected
as the leader of group ng0. term 2.  T2: Restart B.  T3: B start prevote for
ng0, with log message node ng0:127.0.0.1:8011 term 2 start pre_vote T4: B got
prevote grant ack from A with log message node ng0:127.0.0.1:8011:1 received
PreVoteResponse from 127.0.0.1:8001:0 term 2 granted 1 rejected_by_lease 0
disrupted 1 T5: B start to vote.  T6: B got vote grant ack from A. node
ng0:127.0.0.1:8011:1 received RequestVoteResponse from 127.0.0.1:8001:0 term 3
granted 1 rejected_by_lease 0 disrupted 1 T7: B got vote reject from C. node
ng0:127.0.0.1:8011:1 received RequestVoteResponse from 127.0.0.1:8021:0 term 2
granted 0 rejected_by_lease 1 disrupted 0 T8: B become the leader of ng0 with
term 3.

It's a bug that old leader A will accept the prevote and vote from reboot node B