### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ It's widely used inside Baidu to build highly-available systems, such as:
 
 * Play braft with [examples](./example).
 
+* Installing from vcpkg
+  
+  You can download and install `braft` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+  ```sh
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh
+  ./vcpkg integrate install
+  ./vcpkg install braft
+  ```
+  The `braft` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Docs
 
 * Read [overview](./docs/cn/overview.md) to know what you can do with braft.


### PR DESCRIPTION
`braft` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `braft` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `braft`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/braft/portfile.cmake). We try to keep the library maintained as close as possible to the original library.