### PR TITLE
Added operator= for PeerId

### DIFF
--- a/src/braft/configuration.h
+++ b/src/braft/configuration.h
@@ -75,6 +75,8 @@ struct PeerId {
         snprintf(str, sizeof(str), "%s:%d", butil::endpoint2str(addr).c_str(), idx);
         return std::string(str);
     }
+    
+    PeerId& operator=(const PeerId& rhs) = default;
 };
 
 inline bool operator<(const PeerId& id1, const PeerId& id2) {


### PR DESCRIPTION
Added operator= for PeerId to fix compile waring
```bash
/home/work/braft/src/braft/route_table.cpp:56:26: warning: implicitly-declared ‘braft::PeerId& braft::PeerId::operator=(const braft::PeerId&)’ is deprecated [-Wdeprecated-copy]
   56 |         *leader_id = gc->leader;
      |                          ^~~~~~
```