### PR TITLE
fix(examples) replace pthread type with pthread_t

### DIFF
--- a/example/atomic/client.cpp
+++ b/example/atomic/client.cpp
@@ -134,21 +134,24 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
+    std::vector<pthread_t> pids;
     std::vector<SendArg> args;
     for (int i = 1; i <= FLAGS_thread_num; ++i) {
         SendArg arg = { i };
         args.push_back(arg);
     }
-    tids.resize(FLAGS_thread_num);
+
     if (!FLAGS_use_bthread) {
+        pids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
             if (pthread_create(
-                        &tids[i], NULL, sender, &args[i]) != 0) {
+                        &pids[i], NULL, sender, &args[i]) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
         }
     } else {
+        tids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
             if (bthread_start_background(
                         &tids[i], NULL, sender, &args[i]) != 0) {
@@ -170,7 +173,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Counter client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }

--- a/example/block/client.cpp
+++ b/example/block/client.cpp
@@ -122,15 +122,17 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
-    tids.resize(FLAGS_thread_num);
+    std::vector<pthread_t> pids;
     if (!FLAGS_use_bthread) {
+        pids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
-            if (pthread_create(&tids[i], NULL, sender, NULL) != 0) {
+            if (pthread_create(&pids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
         }
     } else {
+        tids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
             if (bthread_start_background(&tids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create bthread";
@@ -151,7 +153,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Block client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }

--- a/example/counter/client.cpp
+++ b/example/counter/client.cpp
@@ -112,15 +112,17 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<bthread_t> tids;
-    tids.resize(FLAGS_thread_num);
+    std::vector<pthread_t> pids;
     if (!FLAGS_use_bthread) {
+        pids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
-            if (pthread_create(&tids[i], NULL, sender, NULL) != 0) {
+            if (pthread_create(&pids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create pthread";
                 return -1;
             }
         }
     } else {
+        tids.resize(FLAGS_thread_num);
         for (int i = 0; i < FLAGS_thread_num; ++i) {
             if (bthread_start_background(&tids[i], NULL, sender, NULL) != 0) {
                 LOG(ERROR) << "Fail to create bthread";
@@ -141,7 +143,7 @@ int main(int argc, char* argv[]) {
     LOG(INFO) << "Counter client is going to quit";
     for (int i = 0; i < FLAGS_thread_num; ++i) {
         if (!FLAGS_use_bthread) {
-            pthread_join(tids[i], NULL);
+            pthread_join(pids[i], NULL);
         } else {
             bthread_join(tids[i], NULL);
         }


### PR DESCRIPTION


Fix examples compile issues on macos13+.

on MacOS13+, `pthread_t` defined as : 

```
typedef __darwin_pthread_t pthread_t;
typedef struct _opaque_pthread_t *__darwin_pthread_t;
struct _opaque_pthread_t {
	long __sig;
	struct __darwin_pthread_handler_rec  *__cleanup_stack;
	char __opaque[__PTHREAD_SIZE__];
};
```

` bthread_t` defined as: `typedef uint64_t bthread_t;`.

`bthread_t` and `pthread_t` are not shared the same type on MacOS SDK anymore,  so we need to declare `tids` and `pids` with respective types.
