### PR TITLE
set st to idle when block timeout

### DIFF
--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -218,6 +218,13 @@ void Replicator::wait_for_caught_up(ReplicatorId id,
 }
 
 void* Replicator::_on_block_timedout_in_new_thread(void* arg) {
+    Replicator* r = NULL;
+    bthread_id_t id = { (uint64_t)arg };
+    if (bthread_id_lock(id, (void**)&r) != 0) {
+        return NULL;
+    }
+    r->_st.st = IDLE;
+    bthread_id_unlock(id);
     Replicator::_continue_sending(arg, ETIMEDOUT);
     return NULL;
 }


### PR DESCRIPTION
replicator blocking状态超时后，需要将状态改回idle。

https://github.com/baidu/braft/blob/334730e618c03bf2989eda474fc600953e000ec0/src/braft/replicator.cpp#L773

```
if (_options.snapshot_throttle && !_options.snapshot_throttle->
                                        add_one_more_task(true)) {
    return _block(butil::gettimeofday_us(), EBUSY);
}
```
如果使用braft默认的SnapshotThrottle，leader在add_one_more_task一定返回true；如果用户自己实现一个SnapshotThrottle，在leader处限制安装快照的任务数，add_one_more_task可能返回false。之后进入_block函数，再也不会send_entry了