### PR TITLE
support arbiter in a new way

### DIFF
--- a/src/braft/errno.proto
+++ b/src/braft/errno.proto
@@ -32,5 +32,9 @@ enum RaftError {
     ENOMOREUSERLOG = 10015;
     // Raft node in readonly mode
     EREADONLY = 10016;
+    // Raft group not in degraded mode
+    ENOTDEGRADED = 10017;
+    // Arbiter node receives non virtual snapshot
+    ESNAPSHOTNOTVIRTUAL = 10018;
 };
 

--- a/src/braft/log_manager.h
+++ b/src/braft/log_manager.h
@@ -149,6 +149,8 @@ public:
     // Get the internal status of LogManager.
     void get_status(LogManagerStatus* status);
 
+    SnapshotReader* get_virtual_snapshot();
+
 private:
 friend class AppendBatcher;
     struct WaitMeta {

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -242,6 +242,10 @@ bool Node::readonly() {
     return _impl->readonly();
 }
 
+bool Node::degraded() {
+    return _impl->degraded();
+}
+
 // ------------- Iterator
 void Iterator::next() {
     if (valid()) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -589,6 +589,17 @@ struct NodeOptions {
     // Default: false
     bool disable_cli;
 
+    // If true, this is an arbiter node. 
+    // Arbiter make it easier to achieve quorums but not maintain a full copy of data.
+    // Arbiter participate in leader election but are not eligible to become leader.
+    // Arbiter will not replicate any log if alive non-arbiter node can achieve quorums.
+    // Arbiter will replicate log's meta if alive non-arbiter node can't achieve quorums.
+    // Arbiter will never call following methods in StateMachine:
+    //   on_apply, on_leader_start, on_leader_stop
+    //   on_snapshot_save, on_snapshot_load, on_snapshot_purge
+    // Default: false
+    bool arbiter;
+
     // Construct a default instance
     NodeOptions();
 
@@ -610,6 +621,7 @@ inline NodeOptions::NodeOptions()
     , snapshot_file_system_adaptor(NULL)
     , snapshot_throttle(NULL)
     , disable_cli(false)
+    , arbiter(false)
 {}
 
 inline int NodeOptions::get_catchup_timeout_ms() {
@@ -774,6 +786,9 @@ public:
     //      - This node is a leader, and the count of writable nodes in the group
     //        is less than the majority.
     bool readonly();
+
+    // Return true if this is the leader, and the group is in degraded mode.
+    bool degraded();
 
 private:
     NodeImpl* _impl;

--- a/src/braft/raft.proto
+++ b/src/braft/raft.proto
@@ -55,6 +55,7 @@ message AppendEntriesResponse {
     required bool success = 2;
     optional int64 last_log_index = 3;
     optional bool readonly = 4;
+    optional bool arbiter = 5;
 };
 
 message SnapshotMeta {

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -336,6 +336,7 @@ public:
     // Copy snapshot from uri and open it as a SnapshotReader
     virtual SnapshotReader* copy_from(const std::string& uri) WARN_UNUSED_RESULT = 0;
     virtual SnapshotCopier* start_to_copy_from(const std::string& uri) = 0;
+    virtual SnapshotCopier* start_to_copy_from(const SnapshotMeta& meta) = 0;
     virtual int close(SnapshotCopier* copier) = 0;
 
     // Create an instance of this kind of SnapshotStorage with the parameters encoded 

--- a/test/test_snapshot_executor.cpp
+++ b/test/test_snapshot_executor.cpp
@@ -179,6 +179,11 @@ public:
         return copier;
     }
 
+    virtual SnapshotCopier* start_to_copy_from(const SnapshotMeta& meta) {
+        return NULL;
+    }
+
+
     virtual int close(SnapshotCopier* copier) {
         delete copier;
         return 0;


### PR DESCRIPTION
支持 arbiter 副本，arbiter 没有用户数据，不维护 FSM，只能发起投票，协助日志提交。

**实现方式**
- 如果group能通过非arbiter节点提交日志，leader 停止向 arbiter 副本复制任何日志（此时 arbiter 副本等价于长时间落后的节点）。
- 如果发现group无法通过非arbiter节点提交日志，group 进入降级模式，leader 重新开始向 arbiter 副本复制日志的元数据 （此时 arbiter 副本帮助提交写请求）。
- leader 需要开始复制日志到 arbiter 上时，总是先安装一个特殊的快照，让 arbiter 快速catch up。这个快照是 leader 临时构造的，只包含元数据，由最新的日志 id 和 conf 构成。

**分析**
一致性：引入arbiter不会影响一致性。
可用性：引入arbiter会降低可用性。考虑以下场景： 3个节点，时刻A ，挂了一个非arbiter节点，此时  leader 通过arbiter提交一些日志。时刻B，旧的leader 挂了，并且挂掉的非arbiter节点恢复。恢复的节点无法成为主，因为缺失了一些日志，会被 arbiter 节点拒绝。这个是可以接受的，因为故障出现了交集，概率非常小。

**对比其他实现**

优点：
1. 正常情况下，leader 与 arbiter 之间只有心跳，开销比较小，可能有助于增加 qps。
2. 不会出现leader挂了，arbiter日志可能更新的问题。

缺点：
1. 写请求时延可能增大（例如，3副本，其中一个为arbiter，log必须同时复制到两个非arbiter节点上才提交， 而不是三个中的任意两个）。
2. 如果非 arbiter follower 故障，检测到降级之前，写请求会失败。


总结：这个方案可以减少空间占用、提高qps，但会增加 latency，降低可用性。考虑到使用 arbiter 的主要目的通常是削减成本，还是比较合适的。