### PR TITLE
renew follower lease after voting

### DIFF
--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1769,6 +1769,7 @@ void NodeImpl::step_down(const int64_t term, bool wakeup_a_candidate,
         _vote_ctx.reset(this);
     } else if (_state == STATE_FOLLOWER) {
         _pre_vote_ctx.reset(this);
+        _follower_lease.renew(PeerId());
     } else if (_state <= STATE_TRANSFERRING) {
         _stepdown_timer.stop();
         _ballot_box->clear_pending_tasks();


### PR DESCRIPTION
related issue: https://github.com/baidu/braft/issues/405

Server remains in follower state as long as it receives valid RPCs from a leader or candidate.

