### PR TITLE
fix: change set_error to set_errorv

### DIFF
--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -939,7 +939,7 @@ void LogManager::report_error(int error_code, const char* fmt, ...) {
     va_start(ap, fmt);
     Error e;
     e.set_type(ERROR_TYPE_LOG);
-    e.status().set_error(error_code, fmt, ap);
+    e.status().set_errorv(error_code, fmt, ap);
     va_end(ap);
     _fsm_caller->on_error(e);
 }


### PR DESCRIPTION
this is part of https://github.com/baidu/braft/pull/270, and we also found this problem in our environment.

<img width="1531" alt="image" src="https://github.com/baidu/braft/assets/10327590/76441552-ec1c-4f97-b068-1eec088c1aec">
