### PR TITLE
rand peer when find_the_next_candidate

### DIFF
--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -1527,20 +1527,32 @@ int ReplicatorGroup::stop_all_and_find_the_next_candidate(
 int ReplicatorGroup::find_the_next_candidate(
         PeerId* peer_id, const ConfigurationEntry& conf) {
     int64_t max_index =  0;
+    struct peerInfo {
+        peerInfo(const PeerId& id, const ReplicatorIdAndStatus& status) {
+            peer_id = id;
+            id_and_status = status;
+        }
+        PeerId peer_id;
+        ReplicatorIdAndStatus id_and_status;
+    };
+    std::vector<peerInfo> peers;
     for (std::map<PeerId, ReplicatorIdAndStatus>::const_iterator
             iter = _rmap.begin();  iter != _rmap.end(); ++iter) {
-        if (!conf.contains(iter->first)) {
+       peers.emplace_back(peerInfo(iter->first,iter->second));
+    }
+    std::random_shuffle(peers.begin(), peers.end());
+    for (auto iter = peers.begin();  iter != peers.end(); ++iter) {
+        if (!conf.contains(iter->peer_id)) {
             continue;
         }
-        const int64_t next_index = Replicator::get_next_index(iter->second.id);
-        const int consecutive_error_times = Replicator::get_consecutive_error_times(iter->second.id);
-        if (consecutive_error_times == 0 && next_index > max_index && !iter->first.is_witness()) {
+        const int64_t next_index = Replicator::get_next_index(iter->id_and_status.id);
+        const int consecutive_error_times = Replicator::get_consecutive_error_times(iter->id_and_status.id);
+        if (consecutive_error_times == 0 && next_index > max_index && !iter->peer_id.is_witness()) {
             max_index = next_index;
             if (peer_id) {
-                *peer_id = iter->first;
+                *peer_id = iter->peer_id;
             }
         }
-        
     }
     if (max_index == 0) {
         return -1;

--- a/test/test_meta.cpp
+++ b/test/test_meta.cpp
@@ -269,7 +269,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_upgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("2.2.2.2:2000:0", peer_bak.to_string());
+        ASSERT_EQ("2.2.2.2:2000:0:0", peer_bak.to_string());
     }
     {
         // _merged_impl already catch up data after Mixed first load
@@ -278,7 +278,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_upgrade) {
         st = tmp->_merged_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("2.2.2.2:2000:0", peer_bak.to_string());
+        ASSERT_EQ("2.2.2.2:2000:0:0", peer_bak.to_string());
     }
 
     // test double write 
@@ -294,14 +294,14 @@ TEST_F(TestUsageSuits, mixed_stable_storage_upgrade) {
         st = tmp->_single_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
         
         term_bak = 0;
         peer_bak.reset();
         st = tmp->_merged_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
     }
     delete storage;
 
@@ -325,7 +325,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_upgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
     }
     // test merged stable storage alone 
     {
@@ -340,7 +340,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_upgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("4.4.4.4:4000:4", peer_bak.to_string());
+        ASSERT_EQ("4.4.4.4:4000:4:0", peer_bak.to_string());
     }
     delete storage; 
 }
@@ -454,7 +454,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_downgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("2.2.2.2:2000:0", peer_bak.to_string());
+        ASSERT_EQ("2.2.2.2:2000:0:0", peer_bak.to_string());
     }
     {
         // _single_impl already catch up data after Mixed first load
@@ -463,7 +463,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_downgrade) {
         st = tmp->_single_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("2.2.2.2:2000:0", peer_bak.to_string());
+        ASSERT_EQ("2.2.2.2:2000:0:0", peer_bak.to_string());
     }
 
     // test double write 
@@ -479,14 +479,14 @@ TEST_F(TestUsageSuits, mixed_stable_storage_downgrade) {
         st = tmp->_single_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
         
         term_bak = 0;
         peer_bak.reset();
         st = tmp->_merged_impl->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
     }
     delete storage;
 
@@ -510,7 +510,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_downgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("3.3.3.3:3000:3", peer_bak.to_string());
+        ASSERT_EQ("3.3.3.3:3000:3:0", peer_bak.to_string());
     }
     // test single stable storage alone 
     {
@@ -525,7 +525,7 @@ TEST_F(TestUsageSuits, mixed_stable_storage_downgrade) {
         st = storage->get_term_and_votedfor(&term_bak, &peer_bak, v_group_id);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(term, term_bak);  
-        ASSERT_EQ("4.4.4.4:4000:4", peer_bak.to_string());
+        ASSERT_EQ("4.4.4.4:4000:4:0", peer_bak.to_string());
     }
     delete storage; 
 }


### PR DESCRIPTION
目前find_the_next_candidate 的逻辑是找到index最新的peerid作为下一个candidate， 但是由于replicagroup是个ordermap， 会导致index没有延时的时候，找到的next candidate都是同一个peer，在multi raft group的情况下，当node进行重启的时候，会导致leader 都 transfer到相同的节点从而导致负载过高。
在 find_the_next_candidate的时候，通过rand 打散，尽可能将leader 分配的不同的peerid， 避免重启的时候leader集中到某一个节点导致瞬间负载过高