### PR TITLE
fix an issue with forgetting to unlock

### DIFF
--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -724,6 +724,7 @@ int Replicator::_continue_sending(void* arg, int error_code) {
         //     1. pipeline is enabled and 
         //     2. disable readonly mode triggers another replication
         if (r->_wait_id != 0) {
+            bthread_id_unlock(id);
             return 0;
         }
         


### PR DESCRIPTION
这里好像忘了放锁，可能导致系统卡住。
其中一个可能卡住的点是：由于这里没有放锁，导致check_dead_nodes卡住（拿不到replicator的锁）；但是check_dead_nodes已经在handle_stepdown_timeout持有braft::NodeImpl::_mutex。进而导致后续所有需要拿braft::NodeImpl::_mutex的地方都被卡住。整个Node不可用。