### PR TITLE
recover log from data corrupt

### DIFF
--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -52,6 +52,9 @@ BRPC_VALIDATE_GFLAG(raft_max_segment_size, brpc::PositiveInteger);
 DEFINE_bool(raft_sync_segments, false, "call fsync when a segment is closed");
 BRPC_VALIDATE_GFLAG(raft_sync_segments, ::brpc::PassValidate);
 
+DEFINE_bool(raft_recover_log_from_corrupt, false, "recover log by truncating corrupted log");
+BRPC_VALIDATE_GFLAG(raft_recover_log_from_corrupt, ::brpc::PassValidate);
+
 static bvar::LatencyRecorder g_open_segment_latency("raft_open_segment");
 static bvar::LatencyRecorder g_segment_append_entry_latency("raft_segment_append_entry");
 static bvar::LatencyRecorder g_sync_segment_latency("raft_sync_segment");
@@ -284,6 +287,7 @@ int Segment::load(ConfigurationManager* configuration_manager) {
     int64_t file_size = st_buf.st_size;
     int64_t entry_off = 0;
     int64_t actual_last_index = _first_index - 1;
+    bool is_entry_corrupted = false;
     for (int64_t i = _first_index; entry_off < file_size; i++) {
         EntryHeader header;
         const int rc = _load_entry(entry_off, &header, NULL, ENTRY_HEADER_SIZE);
@@ -292,6 +296,7 @@ int Segment::load(ConfigurationManager* configuration_manager) {
             break;
         }
         if (rc < 0) {
+            is_entry_corrupted = true;
             ret = rc;
             break;
         }
@@ -345,7 +350,12 @@ int Segment::load(ConfigurationManager* configuration_manager) {
     }
 
     if (ret != 0) {
-        return ret;
+        if (!_is_open || !FLAGS_raft_recover_log_from_corrupt || !is_entry_corrupted) {
+            return ret;
+        // Truncate the log to the last normal index
+        } else {
+          ret = 0; 
+        }
     }
 
     if (_is_open) {

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -354,7 +354,7 @@ int Segment::load(ConfigurationManager* configuration_manager) {
             return ret;
         // Truncate the log to the last normal index
         } else {
-          ret = 0; 
+            ret = 0;
         }
     }
 


### PR DESCRIPTION
在物理机宕机的情况下，由于page cache丢失，导致in progress日志部分数据损坏，无法启动
需要提供能力，可以truncate掉损坏的数据启动