### PR TITLE
sync log immediately when there is configuration

### DIFF
--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -70,7 +70,7 @@ public:
     int close(bool will_sync = true);
 
     // sync open segment
-    int sync(bool will_sync);
+    int sync(bool will_sync, bool has_conf = false);
 
     // unlink segment
     int unlink();


### PR DESCRIPTION
在批量刷sync log的情况下，对于entry是configuration，应该保证同步sync，防止因为configuration丢失出现一些不可预料的错误