### PR TITLE
fix peerid

### DIFF
--- a/src/braft/configuration.h
+++ b/src/braft/configuration.h
@@ -103,13 +103,21 @@ struct PeerId {
 inline bool operator<(const PeerId& id1, const PeerId& id2) {
     if (id1.addr < id2.addr) {
         return true;
-    } else {
-        return id1.addr == id2.addr && id1.idx < id2.idx;
     }
+    if (id2.addr < id1.addr) {
+        return false;
+    }
+    if (id1.idx < id2.idx) {
+        return true;
+    }
+    if (id2.idx < id1.idx) {
+        return false;
+    }
+    return id1.role < id2.role;
 }
 
 inline bool operator==(const PeerId& id1, const PeerId& id2) {
-    return (id1.addr == id2.addr && id1.idx == id2.idx);
+    return (id1.addr == id2.addr && id1.idx == id2.idx && id1.role == id2.role);
 }
 
 inline bool operator!=(const PeerId& id1, const PeerId& id2) {


### PR DESCRIPTION
PeerId  增加了 role，但是它的  operator <  和 operator == 没有考虑 role。
PeerId 的 operator < 被 std::map 使用(包括 Configuration/RaftService)。没有考虑 role 会导新建一个 addr、idx 相同但是角色不同的节点时失败。