### PR TITLE
support set truncate_index manually in on_snapshot_save

### DIFF
--- a/src/braft/fsm_caller.cpp
+++ b/src/braft/fsm_caller.cpp
@@ -345,6 +345,7 @@ void FSMCaller::do_snapshot_save(SaveSnapshotClosure* done) {
             iter != conf_entry.old_conf.end(); ++iter) { 
         *meta.add_old_peers() = iter->to_string();
     }
+    done->set_snapshot_index(last_applied_index);
 
     SnapshotWriter* writer = done->start(meta);
     if (!writer) {

--- a/src/braft/fsm_caller.h
+++ b/src/braft/fsm_caller.h
@@ -95,6 +95,17 @@ class SaveSnapshotClosure : public Closure {
 public:
     // TODO: comments
     virtual SnapshotWriter* start(const SnapshotMeta& meta) = 0;
+
+    void set_snapshot_index(int64_t index){
+        _index = index;
+    }
+
+    int64_t snapshot_index() const {
+        return _index;
+    }
+
+private:
+    int64_t _index;
 };
 
 class LoadSnapshotClosure : public Closure {


### PR DESCRIPTION
In braft, creating a snapshot will result in the truncation of logs,  and users can not decide which logs will be truncated after snapshot_save.
But sometimes, user wants to take over it and decides which logs should be retained.

For example, last_index=20 now,  And snapshot_save is issued, but I don’t want to truncate all the logs before 20. 
On the contrary, logs between 11-20 should be kept and only logs before 11 will be truncated. But now, users can't achieve it.  : (

I believe it will be a useful feature. By fully controlling the truncate index, users can use raft log as WAL of non-volatile StateMachine or to implement CDC etc.