### PR TITLE
Support user specific CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(WITH_DEBUG_SYMBOLS)
     set(DEBUG_SYMBOL "-g")
 endif()
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 include(FindThreads)
 include(FindProtobuf)


### PR DESCRIPTION
Fix for issue #476.
Support for user specific paths to external module configuration that are not inside `${PROJECT_SOURCE_BUILD}/cmake`, making it easier to link `braft` against other projects.