### PR TITLE
snapshot: Transfer files concurrently to speed up snapshot transfer

### DIFF
--- a/src/braft/snapshot.h
+++ b/src/braft/snapshot.h
@@ -161,7 +161,7 @@ private:
     int filter_before_copy(LocalSnapshotWriter* writer, 
                            SnapshotReader* last_snapshot);
     void filter();
-    void copy_file(const std::string& filename);
+    void copy_files(std::span<std::string const> filenames);
 
     raft_mutex_t _mutex;
     bthread_t _tid;


### PR DESCRIPTION
Currently snapshot transfer happens by sending GetFileRequest for every file known to be in the remote snapshot. This happens sequentially for each file.

The only real configurations which allow tuning the throughput of this transfer are the throttle which can be set when initializing the braft::Node, or the runtime configuration raft_max_byte_count_per_rpc which determines how many chunks a large file will be broken into during the transfer. The default is 128KiB, so a 1MiB file will be transfered in about 8 GetFileRequests.

This works great for snapshots which have a handful of large files. But if a snapshot has hundreds or thousands of small files then transfer of these snapshots can be pretty slow.

I locally create a snapshot with 100k files on my development machine, for example, it can take up to 30 minutes to transfer all of those files in that snapshot. Even though the latency per transfer is low, there is a full round trip plus a flush of __raft_meta on the receiving end for each file.

This patch adds concurrency to these transfers. When a remote snapshot is transferred locally, up to raft_max_get_file_request_concurrency GetFileRequests will be sent concurrently. This defaults to 64.

With this patch, the 100k file snapshot consistently transfers in under 10 seconds on my development machine.

This should resolve https://github.com/baidu/braft/issues/362.