### PR TITLE
Support multi-cycle snapshots to overcoming the shortcomings of long …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         build_tool: [cmake, bazel]
         with_test: [true, false]
         exclude:

--- a/src/braft/log_manager.h
+++ b/src/braft/log_manager.h
@@ -39,6 +39,7 @@ struct LogManagerOptions {
     LogStorage* log_storage;
     ConfigurationManager* configuration_manager;
     FSMCaller* fsm_caller;  // To report log error
+    int max_snapshot_cnt;
 };
 
 struct LogManagerStatus {
@@ -216,15 +217,16 @@ friend class AppendBatcher;
     std::deque<LogEntry* /*FIXME*/> _logs_in_memory;
     int64_t _first_log_index;
     int64_t _last_log_index;
-    // the last snapshot's log_id
-    LogId _last_snapshot_id;
     // the virtual first log, for finding next_index of replicator, which 
     // can avoid install_snapshot too often in extreme case where a follower's
     // install_snapshot is slower than leader's save_snapshot
-    // [NOTICE] there should not be hole between this log_id and _last_snapshot_id,
+    // [NOTICE] there should not be hole between this log_id and _last_snapshot_ids,
     // or may cause some unexpect cases
     LogId _virtual_first_log_id;
 
+    // the last snapshots with included log_id
+    std::deque<LogId> _last_snapshot_ids;
+    int _max_snapshot_cnt;
     bthread::ExecutionQueueId<StableClosure*> _disk_queue;
 };
 

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -256,6 +256,7 @@ int NodeImpl::init_snapshot_storage() {
     opt.init_term = _current_term;
     opt.filter_before_copy_remote = _options.filter_before_copy_remote;
     opt.usercode_in_pthread = _options.usercode_in_pthread;
+    opt.max_snapshot_cnt = _options.max_snapshot_cnt;
     // not need to copy data file when it is witness.
     if (_options.witness) {
         opt.copy_file = false;
@@ -287,6 +288,7 @@ int NodeImpl::init_log_storage() {
     log_manager_options.log_storage = _log_storage;
     log_manager_options.configuration_manager = _config_manager;
     log_manager_options.fsm_caller = _fsm_caller;
+    log_manager_options.max_snapshot_cnt = _options.max_snapshot_cnt;
     return _log_manager->init(log_manager_options);
 }
 
@@ -418,6 +420,7 @@ int NodeImpl::bootstrap(const BootstrapOptions& options) {
     _options.log_uri = options.log_uri;
     _options.raft_meta_uri = options.raft_meta_uri;
     _options.snapshot_uri = options.snapshot_uri;
+    _options.max_snapshot_cnt = options.max_snapshot_cnt;
     _config_manager = new ConfigurationManager();
 
     // Create _fsm_caller first as log_manager needs it to report error

--- a/src/braft/raft.cpp
+++ b/src/braft/raft.cpp
@@ -319,6 +319,7 @@ BootstrapOptions::BootstrapOptions()
     , fsm(NULL)
     , node_owns_fsm(false)
     , usercode_in_pthread(false)
+    , max_snapshot_cnt(1)
 {}
 
 int bootstrap(const BootstrapOptions& options) {

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -497,6 +497,10 @@ struct NodeOptions {
     // Default: 3600 (1 hour)
     int snapshot_interval_s;
 
+    // Max snapshot count retained.
+    // Default: 1 
+    int max_snapshot_cnt;
+
     // We will regard a adding peer as caught up if the margin between the
     // last_log_index of this peer and the last_log_index of leader is less than
     // |catchup_margin|
@@ -614,6 +618,7 @@ inline NodeOptions::NodeOptions()
     , catchup_timeout_ms(0)
     , max_clock_drift_ms(1000)
     , snapshot_interval_s(3600)
+    , max_snapshot_cnt(1)
     , catchup_margin(1000)
     , usercode_in_pthread(false)
     , fsm(NULL)
@@ -827,6 +832,10 @@ struct BootstrapOptions {
 
     // Describe a specific SnapshotStorage in format ${type}://${parameters}
     std::string snapshot_uri;
+
+    // Max snapshot count retained.
+    // Default: 1 
+    int max_snapshot_cnt;
 
     // Construct default options
     BootstrapOptions();

--- a/src/braft/snapshot.h
+++ b/src/braft/snapshot.h
@@ -188,11 +188,12 @@ public:
 
     static const char* _s_temp_path;
 
-    virtual int init();
+    virtual int init(const int max_snapshot_cnt);
     virtual SnapshotWriter* create() WARN_UNUSED_RESULT;
     virtual int close(SnapshotWriter* writer);
 
     virtual SnapshotReader* open() WARN_UNUSED_RESULT;
+    virtual SnapshotReader* open_earliest_snapshot_include_index(const int64_t last_include_index) WARN_UNUSED_RESULT;
     virtual int close(SnapshotReader* reader);
     virtual SnapshotReader* copy_from(const std::string& uri) WARN_UNUSED_RESULT;
     virtual SnapshotCopier* start_to_copy_from(const std::string& uri);
@@ -217,7 +218,8 @@ private:
     raft_mutex_t _mutex;
     std::string _path;
     bool _filter_before_copy_remote;
-    int64_t _last_snapshot_index;
+    int _max_snapshot_cnt = 1;
+    std::deque<int64_t> _prev_snapshot_indexes;
     std::map<int64_t, int> _ref_map;
     butil::EndPoint _addr;
     bool _copy_file = true;

--- a/src/braft/snapshot_executor.h
+++ b/src/braft/snapshot_executor.h
@@ -47,6 +47,7 @@ struct SnapshotExecutorOptions {
     bool copy_file = true;
     scoped_refptr<FileSystemAdaptor> file_system_adaptor;
     scoped_refptr<SnapshotThrottle> snapshot_throttle;
+    int max_snapshot_cnt;
 };
 
 // Executing Snapshot related stuff
@@ -173,6 +174,7 @@ inline SnapshotExecutorOptions::SnapshotExecutorOptions()
     , init_term(0)
     , filter_before_copy_remote(false)
     , usercode_in_pthread(false)
+    , max_snapshot_cnt(1)
 {}
 
 }  //  namespace braft

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -321,7 +321,7 @@ public:
     }
 
     // Initialize
-    virtual int init() = 0;
+    virtual int init(const int max_snapshot_cnt) = 0;
 
     // create new snapshot writer
     virtual SnapshotWriter* create() = 0;
@@ -331,6 +331,10 @@ public:
 
     // get lastest snapshot reader
     virtual SnapshotReader* open() = 0;
+
+    // get the earliest snapshot reader which includes the given index
+    virtual SnapshotReader* open_earliest_snapshot_include_index(
+            const int64_t last_include_index) = 0;
 
     // close snapshot reader
     virtual int close(SnapshotReader* reader) = 0;


### PR DESCRIPTION
…and short cycles:

1. Long-cycle snapshots cause slow startup during recover.
2. Short-cycle snapshots lead to frequent install snapshot operations.