### PR TITLE
Fix SaveSnapshotDone and SnapshotWriter leak when done is NULL

### DIFF
--- a/src/braft/snapshot_executor.cpp
+++ b/src/braft/snapshot_executor.cpp
@@ -177,10 +177,8 @@ void SnapshotExecutor::do_snapshot(Closure* done) {
     SaveSnapshotDone* snapshot_save_done = new SaveSnapshotDone(this, writer, done);
     if (_fsm_caller->on_snapshot_save(snapshot_save_done) != 0) {
         lck.unlock();
-        if (done) {
-            snapshot_save_done->status().set_error(EHOSTDOWN, "The raft node is down");
-            run_closure_in_bthread(snapshot_save_done, _usercode_in_pthread);
-        }
+        snapshot_save_done->status().set_error(EHOSTDOWN, "The raft node is down");
+        run_closure_in_bthread(snapshot_save_done, _usercode_in_pthread);
         return;
     }
     _running_jobs.add_count(1);


### PR DESCRIPTION
### Problem

In `SnapshotExecutor::do_snapshot()`, when `_fsm_caller->on_snapshot_save()` fails to enqueue the task and the `done` closure is NULL (timer-triggered snapshot), the `SaveSnapshotDone` object and its contained `SnapshotWriter` are leaked.

```cpp
// snapshot_executor.cpp:178-184
if (_fsm_caller->on_snapshot_save(snapshot_save_done) != 0) {
    lck.unlock();
    if (done) {  // when done == NULL (timer-triggered), this block is skipped
        snapshot_save_done->status().set_error(EHOSTDOWN, "The raft node is down");
        run_closure_in_bthread(snapshot_save_done, _usercode_in_pthread);
    }
    return;  // snapshot_save_done is never run, never deleted
}
```

This was introduced by commit `875e850` which added `if (done)` guards to fix a NULL pointer dereference when `done == NULL`. The fix correctly prevented the crash, but inadvertently skipped running `snapshot_save_done`, which is a separate object that wraps `done` and is responsible for cleanup.

### What is leaked

- `SaveSnapshotDone` object (allocated with `new` at line 177)
- `SnapshotWriter` held by `SaveSnapshotDone`

### Fix

Remove the `if (done)` guard so that `snapshot_save_done` is always run. `SaveSnapshotDone::continue_run()` already handles `_done == NULL` correctly (lines 318-322 check `if (self->_done)` before accessing it), so this is safe.
