### PR TITLE
Fix ambiguous namespace resolution for Sample in bvar::detail

### DIFF
--- a/src/braft/util.cpp
+++ b/src/braft/util.cpp
@@ -47,7 +47,7 @@ namespace detail {
 typedef PercentileSamples<1022> CombinedPercentileSamples;
 
 static int64_t get_window_recorder_qps(void* arg) {
-    detail::Sample<Stat> s;
+    Sample<Stat> s;
     static_cast<RecorderWindow*>(arg)->get_span(1, &s);
     // Use floating point to avoid overflow.
     if (s.time_us <= 0) {


### PR DESCRIPTION
## Summary

- Fix compilation error in `src/braft/util.cpp` caused by ambiguous namespace resolution
- Inside `namespace bvar::detail`, the qualified name `detail::Sample<Stat>` resolves to `bvar::detail::detail::Sample<Stat>` which does not exist
- Changed to unqualified `Sample<Stat>` which correctly resolves to `bvar::detail::Sample<Stat>`

## Background

This issue was discovered when updating the brpc port to 1.16.0 in vcpkg (microsoft/vcpkg#50466). Changes to bvar's internal namespace structure in brpc >= 1.16.0 exposed this pre-existing ambiguity, causing braft to fail to compile.

## Changes

```diff
--- a/src/braft/util.cpp
+++ b/src/braft/util.cpp
@@ -47,7 +47,7 @@ namespace detail {
 typedef PercentileSamples<1022> CombinedPercentileSamples;
 
 static int64_t get_window_recorder_qps(void* arg) {
-    detail::Sample<Stat> s;
+    Sample<Stat> s;
     static_cast<RecorderWindow*>(arg)->get_span(1, &s);
```

## Test Plan

- [x] Verified braft compiles successfully against brpc 1.16.0 with this fix (via vcpkg CI on all 15 platforms: arm64_android, arm64_linux, arm64_osx, arm64_windows, arm64_windows_static_md, arm_neon_android, x64_android, x64_linux, x64_windows, x64_windows_release, x64_windows_static, x64_windows_static_md, x86_windows)
- See: https://github.com/microsoft/vcpkg/pull/50466


Made with [Cursor](https://cursor.com)