### PR TITLE
[Fix] Address deadlock issue during leader stepdown

### DIFF
--- a/src/braft/ballot_box.cpp
+++ b/src/braft/ballot_box.cpp
@@ -106,6 +106,15 @@ int BallotBox::clear_pending_tasks() {
     return 0;
 }
 
+void BallotBox::drain_pending_tasks(std::deque<std::pair<Closure*, bool>>& out) {
+    {
+        BAIDU_SCOPED_LOCK(_mutex);
+        _pending_meta_queue.clear();
+        _pending_index = 0;
+    }
+    _closure_queue->drain(out);
+}
+
 int BallotBox::reset_pending_index(int64_t new_pending_index) {
     BAIDU_SCOPED_LOCK(_mutex);
     CHECK(_pending_index == 0 && _pending_meta_queue.empty())

--- a/src/braft/ballot_box.h
+++ b/src/braft/ballot_box.h
@@ -65,6 +65,10 @@ public:
     // fail immediately, which the new leader will deal whether to commit or
     // truncate.
     int clear_pending_tasks();
+
+    // Drain all pending closures into |out| as (closure, usercode_in_pthread)
+    // pairs. Safe to call while NodeImpl._mutex is held.
+    void drain_pending_tasks(std::deque<std::pair<Closure*, bool>>& out);
     
     // Called when a candidate becomes the new leader, otherwise the behavior is
     // undefined.

--- a/src/braft/closure_queue.cpp
+++ b/src/braft/closure_queue.cpp
@@ -50,6 +50,21 @@ void ClosureQueue::clear() {
     }
 }
 
+void ClosureQueue::drain(std::deque<std::pair<Closure*, bool>>& out) {
+    std::deque<Closure*> tmp;
+    {
+        BAIDU_SCOPED_LOCK(_mutex);
+        tmp.swap(_queue);
+        _first_index = 0;
+    }
+    for (Closure* c : tmp) {
+        if (c) {
+            c->status().set_error(EPERM, "leader stepped down");
+            out.push_back(std::make_pair(c, _usercode_in_pthread));
+        }
+    }
+}
+
 void ClosureQueue::reset_first_index(int64_t first_index) {
     BAIDU_SCOPED_LOCK(_mutex);
     CHECK(_queue.empty());

--- a/src/braft/closure_queue.h
+++ b/src/braft/closure_queue.h
@@ -30,6 +30,11 @@ public:
     // Clear all the pending closure and run done
     void clear();
 
+    // Drain all pending closures into |out| as (closure, usercode_in_pthread)
+    // pairs, marking each with EPERM. Unlike clear(), does not call push_rq or
+    // bthread_flush — safe to call while NodeImpl._mutex is held.
+    void drain(std::deque<std::pair<Closure*, bool>>& out);
+
     // Called when a candidate becomes the new leader, otherwise the behavior is
     // undefined.
     // Reset the first index of the coming pending closures to |first_index|

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -36,7 +36,23 @@
 
 namespace braft {
 
-DEFINE_int32(raft_max_election_delay_ms, 1000, 
+// RAII guard that owns the drained closures and schedules them after _mutex
+// is released. Declare BEFORE the mutex lock so the destructor runs after.
+struct ClosureFlushGuard {
+    std::deque<std::pair<Closure*, bool>> closures;
+    ~ClosureFlushGuard() {
+        if (closures.empty()) { return; }
+        bool run = false;
+        for (std::pair<Closure*, bool>& p : closures) {
+            run_closure_in_bthread_nosig(p.first, p.second);
+            run = true;
+        }
+        closures.clear();
+        if (run) { bthread_flush(); }
+    }
+};
+
+DEFINE_int32(raft_max_election_delay_ms, 1000,
              "Max election delay time allowed by user");
 BRPC_VALIDATE_GFLAG(raft_max_election_delay_ms, brpc::PositiveInteger);
 
@@ -638,13 +654,14 @@ int NodeImpl::init(const NodeOptions& options) {
         _snapshot_timer.start();
     }
 
+    ClosureFlushGuard guard;
     if (!_conf.empty()) {
-        step_down(_current_term, false, butil::Status::OK());
+        step_down(_current_term, false, butil::Status::OK(), guard.closures);
     }
 
     // add node to NodeManager
     if (!global_node_manager->add(this)) {
-        LOG(ERROR) << "NodeManager add " << _group_id 
+        LOG(ERROR) << "NodeManager add " << _group_id
                    << ":" << _server_id << " failed";
         return -1;
     }
@@ -791,7 +808,8 @@ void NodeImpl::on_caughtup(const PeerId& peer, int64_t term,
     _conf_ctx.on_caughtup(version, peer, false);
 }
 
-void NodeImpl::check_dead_nodes(const Configuration& conf, int64_t now_ms) {
+void NodeImpl::check_dead_nodes(const Configuration& conf, int64_t now_ms,
+                                std::deque<std::pair<Closure*, bool>>& drained_closures) {
     std::vector<PeerId> peers;
     conf.list_peers(&peers);
     size_t alive_count = 0;
@@ -819,10 +837,11 @@ void NodeImpl::check_dead_nodes(const Configuration& conf, int64_t now_ms) {
                  << " conf: " << conf;
     butil::Status status;
     status.set_error(ERAFTTIMEDOUT, "Majority of the group dies");
-    step_down(_current_term, false, status);
+    step_down(_current_term, false, status, drained_closures);
 }
 
 void NodeImpl::handle_stepdown_timeout() {
+    ClosureFlushGuard guard;
     BAIDU_SCOPED_LOCK(_mutex);
 
     // check state
@@ -834,9 +853,9 @@ void NodeImpl::handle_stepdown_timeout() {
     }
     check_witness(_conf.conf);
     int64_t now = butil::monotonic_time_ms();
-    check_dead_nodes(_conf.conf, now);
+    check_dead_nodes(_conf.conf, now, guard.closures);
     if (!_conf.old_conf.empty()) {
-        check_dead_nodes(_conf.old_conf, now);
+        check_dead_nodes(_conf.old_conf, now, guard.closures);
     }
 }
 
@@ -848,7 +867,8 @@ void NodeImpl::check_witness(const Configuration& conf) {
                 << " conf: " << conf;
         butil::Status status;
         status.set_error(ETRANSFERLEADERSHIP, "Witness becomes leader temporarily");
-        step_down(_current_term, true, status);
+        ClosureFlushGuard guard;
+        step_down(_current_term, true, status, guard.closures);
     }
 }
 
@@ -919,6 +939,7 @@ void NodeImpl::change_peers(const Configuration& new_peers, Closure* done) {
 }
 
 butil::Status NodeImpl::reset_peers(const Configuration& new_peers) {
+    ClosureFlushGuard guard;
     BAIDU_SCOPED_LOCK(_mutex);
 
     if (new_peers.empty()) {
@@ -938,7 +959,7 @@ butil::Status NodeImpl::reset_peers(const Configuration& new_peers) {
         _conf.conf = new_peers;
         butil::Status status;
         status.set_error(ESETPEER, "Set peer from empty configuration");
-        step_down(_current_term + 1, false, status);
+        step_down(_current_term + 1, false, status, guard.closures);
         return butil::Status::OK();
     }
 
@@ -955,7 +976,7 @@ butil::Status NodeImpl::reset_peers(const Configuration& new_peers) {
     }
 
     Configuration new_conf(new_peers);
-    LOG(WARNING) << "node " << _group_id << ":" << _server_id 
+    LOG(WARNING) << "node " << _group_id << ":" << _server_id
                  << " set_peer from "
                  << _conf.conf << " to " << new_conf;
     // change conf and step_down
@@ -963,7 +984,7 @@ butil::Status NodeImpl::reset_peers(const Configuration& new_peers) {
     _conf.old_conf.reset();
     butil::Status status;
     status.set_error(ESETPEER, "Raft node set peer normally");
-    step_down(_current_term + 1, false, status);
+    step_down(_current_term + 1, false, status, guard.closures);
     return butil::Status::OK();
 }
 
@@ -987,6 +1008,7 @@ void NodeImpl::do_snapshot(Closure* done) {
 void NodeImpl::shutdown(Closure* done) {
     // Note: shutdown is probably invoked more than once, make sure this method
     // is idempotent
+    ClosureFlushGuard guard;
     {
         BAIDU_SCOPED_LOCK(_mutex);
 
@@ -1002,7 +1024,7 @@ void NodeImpl::shutdown(Closure* done) {
             if (_state <= STATE_FOLLOWER) {
                 butil::Status status;
                 status.set_error(ESHUTDOWN, "Raft node is going to quit.");
-                step_down(_current_term, _state == STATE_LEADER, status);
+                step_down(_current_term, _state == STATE_LEADER, status, guard.closures);
             }
 
             // change state to shutdown
@@ -1094,13 +1116,14 @@ void NodeImpl::handle_timeout_now_request(brpc::Controller* controller,
                                           TimeoutNowResponse* response,
                                           google::protobuf::Closure* done) {
     brpc::ClosureGuard done_guard(done);
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
     if (request->term() != _current_term) {
         const int64_t saved_current_term = _current_term;
         if (request->term() > _current_term) {
             butil::Status status;
             status.set_error(EHIGHERTERMREQUEST, "Raft node receives higher term request.");
-            step_down(request->term(), false, status);
+            step_down(request->term(), false, status, guard.closures);
         }
         response->set_term(_current_term);
         response->set_success(false);
@@ -1352,13 +1375,14 @@ void NodeImpl::on_error(const Error& e) {
         // on_error of _fsm_caller is guaranteed to be executed once.
         _fsm_caller->on_error(e);
     }
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
     // if it is leader, need to wake up a new one.
     // if it is follower, also step down to call on_stop_following
     if (_state <= STATE_FOLLOWER) {
         butil::Status status;
         status.set_error(EBADNODE, "Raft node(leader or candidate) is in error.");
-        step_down(_current_term, _state == STATE_LEADER, status);
+        step_down(_current_term, _state == STATE_LEADER, status, guard.closures);
     }
     if (_state < STATE_ERROR) {
         _state = STATE_ERROR;
@@ -1367,6 +1391,7 @@ void NodeImpl::on_error(const Error& e) {
 }
 
 void NodeImpl::handle_vote_timeout() {
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
 
     // check state
@@ -1381,7 +1406,7 @@ void NodeImpl::handle_vote_timeout() {
                         " fail to get quorum vote-granted";
         butil::Status status;
         status.set_error(ERAFTTIMEDOUT, "Fail to get quorum vote-granted");
-        step_down(_current_term, false, status);
+        step_down(_current_term, false, status, guard.closures);
         pre_vote(&lck, false);
     } else {
         // retry vote
@@ -1394,6 +1419,7 @@ void NodeImpl::handle_vote_timeout() {
 void NodeImpl::handle_request_vote_response(const PeerId& peer_id, const int64_t term,
                                             const int64_t ctx_version,
                                             const RequestVoteResponse& response) {
+    ClosureFlushGuard guard;
     BAIDU_SCOPED_LOCK(_mutex);
 
     if (ctx_version != _vote_ctx.version()) {
@@ -1426,7 +1452,7 @@ void NodeImpl::handle_request_vote_response(const PeerId& peer_id, const int64_t
         butil::Status status;
         status.set_error(EHIGHERTERMRESPONSE, "Raft node receives higher term "
                 "request_vote_response.");
-        step_down(response.term(), false, status);
+        step_down(response.term(), false, status, guard.closures);
         return;
     }
 
@@ -1503,6 +1529,7 @@ struct OnRequestVoteRPCDone : public google::protobuf::Closure {
 void NodeImpl::handle_pre_vote_response(const PeerId& peer_id, const int64_t term,
                                         const int64_t ctx_version,
                                         const RequestVoteResponse& response) {
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
 
     if (ctx_version != _pre_vote_ctx.version()) {
@@ -1535,7 +1562,7 @@ void NodeImpl::handle_pre_vote_response(const PeerId& peer_id, const int64_t ter
         butil::Status status;
         status.set_error(EHIGHERTERMRESPONSE, "Raft node receives higher term "
                 "pre_vote_response.");
-        step_down(response.term(), false, status);
+        step_down(response.term(), false, status, guard.closures);
         return;
     }
 
@@ -1790,8 +1817,9 @@ void NodeImpl::request_peers_to_vote(const std::set<PeerId>& peers,
 }
 
 // in lock
-void NodeImpl::step_down(const int64_t term, bool wakeup_a_candidate, 
-                         const butil::Status& status) {
+void NodeImpl::step_down(const int64_t term, bool wakeup_a_candidate,
+                         const butil::Status& status,
+                         std::deque<std::pair<Closure*, bool>>& drained_closures) {
     BRAFT_VLOG << "node " << _group_id << ":" << _server_id
               << " term " << _current_term 
               << " stepdown from " << state2str(_state)
@@ -1809,7 +1837,13 @@ void NodeImpl::step_down(const int64_t term, bool wakeup_a_candidate,
         _pre_vote_ctx.reset(this);
     } else if (_state <= STATE_TRANSFERRING) {
         _stepdown_timer.stop();
-        _ballot_box->clear_pending_tasks();
+        if (_options.flush_done_closures_after_step_down) {
+            std::deque<std::pair<Closure*, bool>> tmp;
+            _ballot_box->drain_pending_tasks(tmp);
+            drained_closures.insert(drained_closures.end(), tmp.begin(), tmp.end());
+        } else {
+            _ballot_box->clear_pending_tasks();
+        }
 
         // signal fsm leader stop immediately
         if (_state == STATE_LEADER) {
@@ -1895,20 +1929,21 @@ void NodeImpl::reset_leader_id(const PeerId& new_leader_id,
 }
 
 // in lock
-void NodeImpl::check_step_down(const int64_t request_term, const PeerId& server_id) {
+void NodeImpl::check_step_down(const int64_t request_term, const PeerId& server_id,
+                               std::deque<std::pair<Closure*, bool>>& drained_closures) {
     butil::Status status;
     if (request_term > _current_term) {
         status.set_error(ENEWLEADER, "Raft node receives message from "
-                "new leader with higher term."); 
-        step_down(request_term, false, status);
-    } else if (_state != STATE_FOLLOWER) { 
+                "new leader with higher term.");
+        step_down(request_term, false, status, drained_closures);
+    } else if (_state != STATE_FOLLOWER) {
         status.set_error(ENEWLEADER, "Candidate receives message "
                 "from new leader with the same term.");
-        step_down(request_term, false, status);
+        step_down(request_term, false, status, drained_closures);
     } else if (_leader_id.is_empty()) {
         status.set_error(ENEWLEADER, "Follower receives message "
                 "from new leader with the same term.");
-        step_down(request_term, false, status); 
+        step_down(request_term, false, status, drained_closures);
     }
     // save current leader
     if (_leader_id.is_empty()) { 
@@ -2175,6 +2210,7 @@ int NodeImpl::handle_pre_vote_request(const RequestVoteRequest* request,
 
 int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
                                           RequestVoteResponse* response) {
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
 
     if (!is_active_state(_state)) {
@@ -2256,7 +2292,7 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
             status.set_error(EHIGHERTERMREQUEST, "Raft node receives higher term "
                     "request_vote_request.");
             disrupted = (_state <= STATE_TRANSFERRING);
-            step_down(request->term(), false, status);
+            step_down(request->term(), false, status, guard.closures);
         }
 
         // save
@@ -2264,7 +2300,7 @@ int NodeImpl::handle_request_vote_request(const RequestVoteRequest* request,
             butil::Status status;
             status.set_error(EVOTEFORCANDIDATE, "Raft node votes for some candidate, "
                     "step down to restart election_timer.");
-            step_down(request->term(), false, status);
+            step_down(request->term(), false, status, guard.closures);
             _voted_id = candidate_id;
             //TODO: outof lock
             status = _meta_storage->
@@ -2392,6 +2428,7 @@ void NodeImpl::handle_append_entries_request(brpc::Controller* cntl,
     std::vector<LogEntry*> entries;
     entries.reserve(request->entries_size());
     brpc::ClosureGuard done_guard(done);
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
 
     // pre set term, to avoid get term in lock
@@ -2435,17 +2472,17 @@ void NodeImpl::handle_append_entries_request(brpc::Controller* cntl,
     }
 
     // check term and state to step down
-    check_step_down(request->term(), server_id);   
-     
+    check_step_down(request->term(), server_id, guard.closures);
+
     if (server_id != _leader_id) {
         LOG(ERROR) << "Another peer " << _group_id << ":" << server_id
-                   << " declares that it is the leader at term=" << _current_term 
+                   << " declares that it is the leader at term=" << _current_term
                    << " which was occupied by leader=" << _leader_id;
         // Increase the term by 1 and make both leaders step down to minimize the
         // loss of split brain
         butil::Status status;
-        status.set_error(ELEADERCONFLICT, "More than one leader in the same term."); 
-        step_down(request->term() + 1, false, status);
+        status.set_error(ELEADERCONFLICT, "More than one leader in the same term.");
+        step_down(request->term() + 1, false, status, guard.closures);
         response->set_success(false);
         response->set_term(request->term() + 1);
         return;
@@ -2573,11 +2610,12 @@ void NodeImpl::handle_append_entries_request(brpc::Controller* cntl,
 }
 
 int NodeImpl::increase_term_to(int64_t new_term, const butil::Status& status) {
+    ClosureFlushGuard guard;
     BAIDU_SCOPED_LOCK(_mutex);
     if (new_term <= _current_term) {
         return EINVAL;
     }
-    step_down(new_term, false, status);
+    step_down(new_term, false, status, guard.closures);
     return 0;
 }
 
@@ -2617,6 +2655,7 @@ void NodeImpl::handle_install_snapshot_request(brpc::Controller* cntl,
                         request->server_id().c_str());
         return;
     }
+    ClosureFlushGuard guard;
     std::unique_lock<raft_mutex_t> lck(_mutex);
     
     if (!is_active_state(_state)) {
@@ -2642,17 +2681,17 @@ void NodeImpl::handle_install_snapshot_request(brpc::Controller* cntl,
         return;
     }
     
-    check_step_down(request->term(), server_id);
+    check_step_down(request->term(), server_id, guard.closures);
 
     if (server_id != _leader_id) {
         LOG(ERROR) << "Another peer " << _group_id << ":" << server_id
-                   << " declares that it is the leader at term=" << _current_term 
+                   << " declares that it is the leader at term=" << _current_term
                    << " which was occupied by leader=" << _leader_id;
         // Increase the term by 1 and make both leaders step down to minimize the
         // loss of split brain
         butil::Status status;
-        status.set_error(ELEADERCONFLICT, "More than one leader in the same term."); 
-        step_down(request->term() + 1, false, status);
+        status.set_error(ELEADERCONFLICT, "More than one leader in the same term.");
+        step_down(request->term() + 1, false, status, guard.closures);
         response->set_success(false);
         response->set_term(request->term() + 1);
         return;
@@ -3308,13 +3347,15 @@ void NodeImpl::ConfigurationCtx::next_stage() {
                     Configuration(_new_peers), NULL, false);
     case STAGE_STABLE:
         {
-            bool should_step_down = 
+            bool should_step_down =
                 _new_peers.find(_node->_server_id) == _new_peers.end();
             butil::Status st = butil::Status::OK();
             reset(&st);
             if (should_step_down) {
+                ClosureFlushGuard guard_local;
                 _node->step_down(_node->_current_term, true,
-                        butil::Status(ELEADERREMOVED, "This node was removed"));
+                        butil::Status(ELEADERREMOVED, "This node was removed"),
+                        guard_local.closures);
             }
             return;
         }
@@ -3453,6 +3494,7 @@ void NodeImpl::get_leader_lease_status(LeaderLeaseStatus* lease_status) {
             break;
     }
 
+    ClosureFlushGuard guard;
     BAIDU_SCOPED_LOCK(_mutex);
     if (_state != STATE_LEADER) {
         lease_status->state = LEASE_EXPIRED;
@@ -3464,7 +3506,7 @@ void NodeImpl::get_leader_lease_status(LeaderLeaseStatus* lease_status) {
     if (internal_info.state != LeaderLease::VALID && internal_info.state != LeaderLease::DISABLED) {
         butil::Status status;
         status.set_error(ERAFTTIMEDOUT, "Leader lease expired");
-        step_down(_current_term, false, status);
+        step_down(_current_term, false, status, guard.closures);
         lease_status->state = LEASE_EXPIRED;
     } else if (internal_info.state == LeaderLease::VALID) {
         lease_status->term = internal_info.term;

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -19,6 +19,7 @@
 #ifndef BRAFT_RAFT_NODE_H
 #define BRAFT_RAFT_NODE_H
 
+#include <deque>
 #include <set>
 #include <butil/atomic_ref_count.h>
 #include <butil/memory/ref_counted.h>
@@ -261,7 +262,8 @@ friend class butil::RefCountedThreadSafe<NodeImpl>;
 
     // step down to follower, status give the reason
     void step_down(const int64_t term, bool wakeup_a_candidate,
-                   const butil::Status& status);
+                   const butil::Status& status,
+                   std::deque<std::pair<Closure*, bool>>& drained_closures);
 
     // reset leader_id. 
     // When new_leader_id is NULL, it means this node just stop following a leader; 
@@ -271,7 +273,8 @@ friend class butil::RefCountedThreadSafe<NodeImpl>;
 
     // check weather to step_down when receiving append_entries/install_snapshot
     // requests.
-    void check_step_down(const int64_t term, const PeerId& server_id);
+    void check_step_down(const int64_t term, const PeerId& server_id,
+                         std::deque<std::pair<Closure*, bool>>& drained_closures);
 
     // pre vote before elect_self
     void pre_vote(std::unique_lock<raft_mutex_t>* lck, bool triggered);
@@ -304,7 +307,8 @@ friend class butil::RefCountedThreadSafe<NodeImpl>;
     static int execute_applying_tasks(
                 void* meta, bthread::TaskIterator<LogEntryAndClosure>& iter);
     void apply(LogEntryAndClosure tasks[], size_t size);
-    void check_dead_nodes(const Configuration& conf, int64_t now_ms);
+    void check_dead_nodes(const Configuration& conf, int64_t now_ms,
+                          std::deque<std::pair<Closure*, bool>>& drained_closures);
     void check_witness(const Configuration& conf);
     bool handle_out_of_order_append_entries(brpc::Controller* cntl,
                                             const AppendEntriesRequest* request,

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -1,11 +1,11 @@
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,23 +19,23 @@
 #ifndef BRAFT_RAFT_NODE_H
 #define BRAFT_RAFT_NODE_H
 
-#include <set>
-#include <butil/atomic_ref_count.h>
-#include <butil/memory/ref_counted.h>
-#include <butil/iobuf.h>
-#include <bthread/execution_queue.h>
-#include <brpc/server.h>
-#include "braft/raft.h"
-#include "braft/log_manager.h"
 #include "braft/ballot_box.h"
-#include "braft/storage.h"
-#include "braft/raft_service.h"
-#include "braft/fsm_caller.h"
-#include "braft/replicator.h"
-#include "braft/util.h"
 #include "braft/closure_queue.h"
 #include "braft/configuration_manager.h"
+#include "braft/fsm_caller.h"
+#include "braft/log_manager.h"
+#include "braft/raft.h"
+#include "braft/raft_service.h"
 #include "braft/repeated_timer_task.h"
+#include "braft/replicator.h"
+#include "braft/storage.h"
+#include "braft/util.h"
+#include <brpc/server.h>
+#include <bthread/execution_queue.h>
+#include <butil/atomic_ref_count.h>
+#include <butil/iobuf.h>
+#include <butil/memory/ref_counted.h>
+#include <set>
 
 namespace braft {
 
@@ -48,493 +48,506 @@ class StopTransferArg;
 class NodeImpl;
 class NodeTimer : public RepeatedTimerTask {
 public:
-    NodeTimer() : _node(NULL) {}
-    virtual ~NodeTimer() {}
-    int init(NodeImpl* node, int timeout_ms);
-    virtual void run() = 0;
+  NodeTimer() : _node(NULL) {}
+  virtual ~NodeTimer() {}
+  int init(NodeImpl *node, int timeout_ms);
+  virtual void run() = 0;
+
 protected:
-    void on_destroy();
-    NodeImpl* _node;
+  void on_destroy();
+  NodeImpl *_node;
 };
 
 class ElectionTimer : public NodeTimer {
 protected:
-    void run();
-    int adjust_timeout_ms(int timeout_ms);
+  void run();
+  int adjust_timeout_ms(int timeout_ms);
 };
 
 class VoteTimer : public NodeTimer {
 protected:
-    void run();
-    int adjust_timeout_ms(int timeout_ms);
+  void run();
+  int adjust_timeout_ms(int timeout_ms);
 };
 
 class StepdownTimer : public NodeTimer {
 protected:
-    void run();
+  void run();
 };
 
 class SnapshotTimer : public NodeTimer {
 public:
-    SnapshotTimer() : _first_schedule(true) {}
+  SnapshotTimer() : _first_schedule(true) {}
+
 protected:
-    void run();
-    int adjust_timeout_ms(int timeout_ms);
+  void run();
+  int adjust_timeout_ms(int timeout_ms);
+
 private:
-    bool _first_schedule;
+  bool _first_schedule;
 };
 
-class BAIDU_CACHELINE_ALIGNMENT NodeImpl 
-        : public butil::RefCountedThreadSafe<NodeImpl> {
-friend class RaftServiceImpl;
-friend class RaftStatImpl;
-friend class FollowerStableClosure;
-friend class ConfigurationChangeDone;
-friend class VoteBallotCtx;
+class BAIDU_CACHELINE_ALIGNMENT NodeImpl
+    : public butil::RefCountedThreadSafe<NodeImpl> {
+  friend class RaftServiceImpl;
+  friend class RaftStatImpl;
+  friend class FollowerStableClosure;
+  friend class ConfigurationChangeDone;
+  friend class VoteBallotCtx;
+
 public:
-    NodeImpl(const GroupId& group_id, const PeerId& peer_id);
-    NodeImpl();
+  NodeImpl(const GroupId &group_id, const PeerId &peer_id);
+  NodeImpl();
 
-    NodeId node_id() const {
-        return NodeId(_group_id, _server_id);
-    }
+  NodeId node_id() const { return NodeId(_group_id, _server_id); }
 
-    PeerId leader_id() {
-        BAIDU_SCOPED_LOCK(_mutex);
-        return _leader_id;
-    }
+  PeerId leader_id() {
+    BAIDU_SCOPED_LOCK(_mutex);
+    return _leader_id;
+  }
 
-    bool is_leader() {
-        BAIDU_SCOPED_LOCK(_mutex);
-        return _state == STATE_LEADER;
-    }
+  bool is_leader() {
+    BAIDU_SCOPED_LOCK(_mutex);
+    return _state == STATE_LEADER;
+  }
 
-    // public user api
-    //
-    // init node
-    int init(const NodeOptions& options);
+  // public user api
+  //
+  // init node
+  int init(const NodeOptions &options);
 
-    // shutdown local replica
-    // done is user defined function, maybe response to client or clean some resource
-    void shutdown(Closure* done);
+  // shutdown local replica
+  // done is user defined function, maybe response to client or clean some
+  // resource
+  void shutdown(Closure *done);
 
-    // Block the thread until the node is successfully stopped.
-    void join();
+  // Block the thread until the node is successfully stopped.
+  void join();
 
-    // apply task to the replicated-state-machine
-    //
-    // About the ownership:
-    // |task.data|: for the performance consideration, we will take way the 
-    //              content. If you want keep the content, copy it before call
-    //              this function
-    // |task.done|: If the data is successfully committed to the raft group. We
-    //              will pass the ownership to StateMachine::on_apply.
-    //              Otherwise we will specifit the error and call it.
-    //
-    void apply(const Task& task);
+  // apply task to the replicated-state-machine
+  //
+  // About the ownership:
+  // |task.data|: for the performance consideration, we will take way the
+  //              content. If you want keep the content, copy it before call
+  //              this function
+  // |task.done|: If the data is successfully committed to the raft group. We
+  //              will pass the ownership to StateMachine::on_apply.
+  //              Otherwise we will specifit the error and call it.
+  //
+  void apply(const Task &task);
 
-    butil::Status list_peers(std::vector<PeerId>* peers);
+  butil::Status list_peers(std::vector<PeerId> *peers);
 
-    // @Node configuration change
-    void add_peer(const PeerId& peer, Closure* done);
-    void remove_peer(const PeerId& peer, Closure* done);
-    void change_peers(const Configuration& new_peers, Closure* done);
-    butil::Status reset_peers(const Configuration& new_peers);
+  // @Node configuration change
+  void add_peer(const PeerId &peer, Closure *done);
+  void remove_peer(const PeerId &peer, Closure *done);
+  void change_peers(const Configuration &new_peers, Closure *done);
+  butil::Status reset_peers(const Configuration &new_peers);
 
-    // trigger snapshot
-    void snapshot(Closure* done);
+  // trigger snapshot
+  void snapshot(Closure *done);
 
-    // trigger vote
-    butil::Status vote(int election_timeout);
+  // trigger vote
+  butil::Status vote(int election_timeout);
 
-    // reset the election_timeout for the very node
-    butil::Status reset_election_timeout_ms(int election_timeout_ms);
-    void reset_election_timeout_ms(int election_timeout_ms, int max_clock_drift_ms);
+  // reset the election_timeout for the very node
+  butil::Status reset_election_timeout_ms(int election_timeout_ms);
+  void reset_election_timeout_ms(int election_timeout_ms,
+                                 int max_clock_drift_ms);
 
-    // rpc request proc func
-    //
-    // handle received PreVote
-    int handle_pre_vote_request(const RequestVoteRequest* request,
-                                RequestVoteResponse* response);
-    // handle received RequestVote
-    int handle_request_vote_request(const RequestVoteRequest* request,
-                     RequestVoteResponse* response);
+  // rpc request proc func
+  //
+  // handle received PreVote
+  int handle_pre_vote_request(const RequestVoteRequest *request,
+                              RequestVoteResponse *response);
+  // handle received RequestVote
+  int handle_request_vote_request(const RequestVoteRequest *request,
+                                  RequestVoteResponse *response);
 
-    // handle received AppendEntries
-    void handle_append_entries_request(brpc::Controller* cntl,
-                                      const AppendEntriesRequest* request,
-                                      AppendEntriesResponse* response,
-                                      google::protobuf::Closure* done,
-                                      bool from_append_entries_cache = false);
+  // handle received AppendEntries
+  void handle_append_entries_request(brpc::Controller *cntl,
+                                     const AppendEntriesRequest *request,
+                                     AppendEntriesResponse *response,
+                                     google::protobuf::Closure *done,
+                                     bool from_append_entries_cache = false);
 
-    // handle received InstallSnapshot
-    void handle_install_snapshot_request(brpc::Controller* controller,
-                                        const InstallSnapshotRequest* request,
-                                        InstallSnapshotResponse* response,
-                                        google::protobuf::Closure* done);
+  // handle received InstallSnapshot
+  void handle_install_snapshot_request(brpc::Controller *controller,
+                                       const InstallSnapshotRequest *request,
+                                       InstallSnapshotResponse *response,
+                                       google::protobuf::Closure *done);
 
-    void handle_timeout_now_request(brpc::Controller* controller,
-                                    const TimeoutNowRequest* request,
-                                    TimeoutNowResponse* response,
-                                    google::protobuf::Closure* done);
-    // timer func
-    void handle_election_timeout();
-    void handle_vote_timeout();
-    void handle_stepdown_timeout();
-    void handle_snapshot_timeout();
-    void handle_transfer_timeout(int64_t term, const PeerId& peer);
+  void handle_timeout_now_request(brpc::Controller *controller,
+                                  const TimeoutNowRequest *request,
+                                  TimeoutNowResponse *response,
+                                  google::protobuf::Closure *done);
+  // timer func
+  void handle_election_timeout();
+  void handle_vote_timeout();
+  void handle_stepdown_timeout();
+  void handle_snapshot_timeout();
+  void handle_transfer_timeout(int64_t term, const PeerId &peer);
 
-    // Closure call func
-    //
-    void handle_pre_vote_response(const PeerId& peer_id, const int64_t term,
-                                  const int64_t ctx_version,
-                                  const RequestVoteResponse& response);
-    void handle_request_vote_response(const PeerId& peer_id, const int64_t term,
-                                      const int64_t ctx_version,
-                                      const RequestVoteResponse& response);
-    void on_caughtup(const PeerId& peer, int64_t term, 
-                     int64_t version, const butil::Status& st);
-    // other func
-    //
-    // called when leader change configuration done, ref with FSMCaller
-    void on_configuration_change_done(int64_t term);
+  // Closure call func
+  //
+  void handle_pre_vote_response(const PeerId &peer_id, const int64_t term,
+                                const int64_t ctx_version,
+                                const RequestVoteResponse &response);
+  void handle_request_vote_response(const PeerId &peer_id, const int64_t term,
+                                    const int64_t ctx_version,
+                                    const RequestVoteResponse &response);
+  void on_caughtup(const PeerId &peer, int64_t term, int64_t version,
+                   const butil::Status &st);
+  // other func
+  //
+  // called when leader change configuration done, ref with FSMCaller
+  void on_configuration_change_done(int64_t term);
 
-    // Called when leader lease is safe to start.
-    void leader_lease_start(int64_t lease_epoch);
+  // Called when leader lease is safe to start.
+  void leader_lease_start(int64_t lease_epoch);
 
-    // called when leader recv greater term in AppendEntriesResponse, ref with Replicator
-    int increase_term_to(int64_t new_term, const butil::Status& status);
+  // called when leader recv greater term in AppendEntriesResponse, ref with
+  // Replicator
+  int increase_term_to(int64_t new_term, const butil::Status &status);
 
-    // Temporary solution
-    void update_configuration_after_installing_snapshot();
+  // Temporary solution
+  void update_configuration_after_installing_snapshot();
 
-    void describe(std::ostream& os, bool use_html);
- 
-    // Get the internal status of this node, the information is mostly the same as we
-    // see from the website, which is generated by |describe| actually.
-    void get_status(NodeStatus* status);
+  void describe(std::ostream &os, bool use_html);
 
-    // Readonly mode func
-    void enter_readonly_mode();
-    void leave_readonly_mode();
-    bool readonly();
-    int change_readonly_config(int64_t term, const PeerId& peer_id, bool readonly);
-    void check_majority_nodes_readonly();
-    void check_majority_nodes_readonly(const Configuration& conf);
+  // Get the internal status of this node, the information is mostly the same as
+  // we see from the website, which is generated by |describe| actually.
+  void get_status(NodeStatus *status);
 
-    // Lease func
-    bool is_leader_lease_valid();
-    void get_leader_lease_status(LeaderLeaseStatus* status);
+  // Readonly mode func
+  void enter_readonly_mode();
+  void leave_readonly_mode();
+  bool readonly();
+  int change_readonly_config(int64_t term, const PeerId &peer_id,
+                             bool readonly);
+  void check_majority_nodes_readonly();
+  void check_majority_nodes_readonly(const Configuration &conf);
 
-    // Call on_error when some error happens, after this is called.
-    // After this point:
-    //  - This node is to step down immediately if it was the leader.
-    //  - Any futuer operation except shutdown would fail, including any RPC
-    //    request.
-    void on_error(const Error& e);
+  // Lease func
+  bool is_leader_lease_valid();
+  void get_leader_lease_status(LeaderLeaseStatus *status);
 
-    int transfer_leadership_to(const PeerId& peer);
-    
-    butil::Status read_committed_user_log(const int64_t index, UserLog* user_log);
+  // Call on_error when some error happens, after this is called.
+  // After this point:
+  //  - This node is to step down immediately if it was the leader.
+  //  - Any futuer operation except shutdown would fail, including any RPC
+  //    request.
+  void on_error(const Error &e);
 
-    int bootstrap(const BootstrapOptions& options);
+  int transfer_leadership_to(const PeerId &peer);
 
-    bool disable_cli() const { return _options.disable_cli; }
-    bool is_witness() const { return _options.witness; }
-private:
-friend class butil::RefCountedThreadSafe<NodeImpl>;
+  butil::Status read_committed_user_log(const int64_t index, UserLog *user_log);
 
-    virtual ~NodeImpl();
-    // internal init func
-    int init_snapshot_storage();
-    int init_log_storage();
-    int init_meta_storage();
-    int init_fsm_caller(const LogId& bootstrap_index);
-    void unsafe_register_conf_change(const Configuration& old_conf,
-                                     const Configuration& new_conf,
-                                     Closure* done);
-    void stop_replicator(const std::set<PeerId>& keep,
-                         const std::set<PeerId>& drop);
+  int bootstrap(const BootstrapOptions &options);
 
-    // become leader
-    void become_leader();
-
-    // step down to follower, status give the reason
-    void step_down(const int64_t term, bool wakeup_a_candidate,
-                   const butil::Status& status);
-
-    // reset leader_id. 
-    // When new_leader_id is NULL, it means this node just stop following a leader; 
-    // otherwise, it means setting this node's leader_id to new_leader_id.
-    // status gives the situation under which this method is called.
-    void reset_leader_id(const PeerId& new_leader_id, const butil::Status& status);
-
-    // check weather to step_down when receiving append_entries/install_snapshot
-    // requests.
-    void check_step_down(const int64_t term, const PeerId& server_id);
-
-    // pre vote before elect_self
-    void pre_vote(std::unique_lock<raft_mutex_t>* lck, bool triggered);
-
-    // elect self to candidate
-    // If old leader has already stepped down, the candidate can vote without 
-    // taking account of leader lease
-    void elect_self(std::unique_lock<raft_mutex_t>* lck, 
-                    bool old_leader_stepped_down = false);
-
-    // grant self a vote
-    class VoteBallotCtx;
-    void grant_self(VoteBallotCtx* vote_ctx, std::unique_lock<raft_mutex_t>* lck);
-    static void on_grant_self_timedout(void* arg);
-    static void* handle_grant_self_timedout(void* arg);
-
-    // leader async apply configuration
-    void unsafe_apply_configuration(const Configuration& new_conf,
-                                    const Configuration* old_conf,
-                                    bool leader_start);
-
-    void do_snapshot(Closure* done);
-
-    void after_shutdown();
-    static void after_shutdown(NodeImpl* node);
-
-    void do_apply(butil::IOBuf& data, Closure* done);
-
-    struct LogEntryAndClosure;
-    static int execute_applying_tasks(
-                void* meta, bthread::TaskIterator<LogEntryAndClosure>& iter);
-    void apply(LogEntryAndClosure tasks[], size_t size);
-    void check_dead_nodes(const Configuration& conf, int64_t now_ms);
-    void check_witness(const Configuration& conf);
-    bool handle_out_of_order_append_entries(brpc::Controller* cntl,
-                                            const AppendEntriesRequest* request,
-                                            AppendEntriesResponse* response,
-                                            google::protobuf::Closure* done,
-                                            int64_t local_last_index);
-    void check_append_entries_cache(int64_t local_last_index);
-    void clear_append_entries_cache();
-    static void* handle_append_entries_from_cache(void* arg);
-    static void on_append_entries_cache_timedout(void* arg);
-    static void* handle_append_entries_cache_timedout(void* arg);
-
-    int64_t last_leader_active_timestamp();
-    int64_t last_leader_active_timestamp(const Configuration& conf);
-    void unsafe_reset_election_timeout_ms(int election_timeout_ms,
-                                          int max_clock_drift_ms);
-    void retry_vote_on_reserved_peers();
-    struct DisruptedLeader;
-    void request_peers_to_vote(const std::set<PeerId>& peers,
-                               const DisruptedLeader& disrupted_leader);
+  bool disable_cli() const { return _options.disable_cli; }
+  bool is_witness() const { return _options.witness; }
 
 private:
+  friend class butil::RefCountedThreadSafe<NodeImpl>;
 
-    class ConfigurationCtx {
+  virtual ~NodeImpl();
+  // internal init func
+  int init_snapshot_storage();
+  int init_log_storage();
+  int init_meta_storage();
+  int init_fsm_caller(const LogId &bootstrap_index);
+  void unsafe_register_conf_change(const Configuration &old_conf,
+                                   const Configuration &new_conf,
+                                   Closure *done);
+  void stop_replicator(const std::set<PeerId> &keep,
+                       const std::set<PeerId> &drop);
+
+  // become leader
+  void become_leader();
+
+  // step down to follower, status give the reason
+  // drained_closures: if non-null and flush_done_closures_after_step_down is
+  // enabled, pending closures are drained into it as (closure, usercode_in_pthread)
+  // pairs rather than scheduled inline. Caller must schedule after releasing _mutex.
+  void step_down(const int64_t term, bool wakeup_a_candidate,
+                 const butil::Status &status,
+                 std::deque<std::pair<Closure*, bool>>& drained_closures);
+
+  // reset leader_id.
+  // When new_leader_id is NULL, it means this node just stop following a
+  // leader; otherwise, it means setting this node's leader_id to new_leader_id.
+  // status gives the situation under which this method is called.
+  void reset_leader_id(const PeerId &new_leader_id,
+                       const butil::Status &status);
+
+  // check weather to step_down when receiving append_entries/install_snapshot
+  // requests.
+  void check_step_down(const int64_t term, const PeerId &server_id,
+                       std::deque<std::pair<Closure*, bool>>& drained_closures);
+
+  // pre vote before elect_self
+  void pre_vote(std::unique_lock<raft_mutex_t> *lck, bool triggered);
+
+  // elect self to candidate
+  // If old leader has already stepped down, the candidate can vote without
+  // taking account of leader lease
+  void elect_self(std::unique_lock<raft_mutex_t> *lck,
+                  bool old_leader_stepped_down = false);
+
+  // grant self a vote
+  class VoteBallotCtx;
+  void grant_self(VoteBallotCtx *vote_ctx, std::unique_lock<raft_mutex_t> *lck);
+  static void on_grant_self_timedout(void *arg);
+  static void *handle_grant_self_timedout(void *arg);
+
+  // leader async apply configuration
+  void unsafe_apply_configuration(const Configuration &new_conf,
+                                  const Configuration *old_conf,
+                                  bool leader_start);
+
+  void do_snapshot(Closure *done);
+
+  void after_shutdown();
+  static void after_shutdown(NodeImpl *node);
+
+  void do_apply(butil::IOBuf &data, Closure *done);
+
+  struct LogEntryAndClosure;
+  static int
+  execute_applying_tasks(void *meta,
+                         bthread::TaskIterator<LogEntryAndClosure> &iter);
+  void apply(LogEntryAndClosure tasks[], size_t size);
+  void check_dead_nodes(const Configuration &conf, int64_t now_ms,
+                        std::deque<std::pair<Closure*, bool>>& drained_closures);
+  void check_witness(const Configuration &conf);
+  bool handle_out_of_order_append_entries(brpc::Controller *cntl,
+                                          const AppendEntriesRequest *request,
+                                          AppendEntriesResponse *response,
+                                          google::protobuf::Closure *done,
+                                          int64_t local_last_index);
+  void check_append_entries_cache(int64_t local_last_index);
+  void clear_append_entries_cache();
+  static void *handle_append_entries_from_cache(void *arg);
+  static void on_append_entries_cache_timedout(void *arg);
+  static void *handle_append_entries_cache_timedout(void *arg);
+
+  int64_t last_leader_active_timestamp();
+  int64_t last_leader_active_timestamp(const Configuration &conf);
+  void unsafe_reset_election_timeout_ms(int election_timeout_ms,
+                                        int max_clock_drift_ms);
+  void retry_vote_on_reserved_peers();
+  struct DisruptedLeader;
+  void request_peers_to_vote(const std::set<PeerId> &peers,
+                             const DisruptedLeader &disrupted_leader);
+
+private:
+  class ConfigurationCtx {
     DISALLOW_COPY_AND_ASSIGN(ConfigurationCtx);
-    public:
-        enum Stage {
-            // Don't change the order if you are not sure about the usage
-            STAGE_NONE = 0,
-            STAGE_CATCHING_UP = 1,
-            STAGE_JOINT = 2,
-            STAGE_STABLE = 3,
-        };
-        ConfigurationCtx(NodeImpl* node) :
-            _node(node), _stage(STAGE_NONE), _version(0), _done(NULL) {}
-        void list_new_peers(std::vector<PeerId>* new_peers) const {
-            new_peers->clear();
-            std::set<PeerId>::iterator it;
-            for (it = _new_peers.begin(); it != _new_peers.end(); ++it) {
-                new_peers->push_back(*it);
-            }
-        }
-        void list_old_peers(std::vector<PeerId>* old_peers) const {
-            old_peers->clear();
-            std::set<PeerId>::iterator it;
-            for (it = _old_peers.begin(); it != _old_peers.end(); ++it) {
-                old_peers->push_back(*it);
-            }
-        }
-        const char* stage_str() {
-            const char* str[] = {"STAGE_NONE", "STAGE_CATCHING_UP", 
-                                 "STAGE_JOINT", "STAGE_STABLE", };
-            if (_stage <= STAGE_STABLE) {
-                return str[(int)_stage];
-            } else {
-                return "UNKNOWN";
-            }
-        }
-        int32_t stage() const { return _stage; }
-        void reset(butil::Status* st = NULL);
-        bool is_busy() const { return _stage != STAGE_NONE; }
-        // Start change configuration.
-        void start(const Configuration& old_conf, 
-                   const Configuration& new_conf,
-                   Closure * done);
-        // Invoked when this node becomes the leader, write a configuration
-        // change log as the first log
-        void flush(const Configuration& conf,
-                   const Configuration& old_conf);
-        void next_stage();
-        void on_caughtup(int64_t version, const PeerId& peer_id, bool succ);
-    private:
-        NodeImpl* _node;
-        Stage _stage;
-        int _nchanges;
-        int64_t _version;
-        std::set<PeerId> _new_peers;
-        std::set<PeerId> _old_peers;
-        std::set<PeerId> _adding_peers;
-        Closure* _done;
+
+  public:
+    enum Stage {
+      // Don't change the order if you are not sure about the usage
+      STAGE_NONE = 0,
+      STAGE_CATCHING_UP = 1,
+      STAGE_JOINT = 2,
+      STAGE_STABLE = 3,
     };
+    ConfigurationCtx(NodeImpl *node)
+        : _node(node), _stage(STAGE_NONE), _version(0), _done(NULL) {}
+    void list_new_peers(std::vector<PeerId> *new_peers) const {
+      new_peers->clear();
+      std::set<PeerId>::iterator it;
+      for (it = _new_peers.begin(); it != _new_peers.end(); ++it) {
+        new_peers->push_back(*it);
+      }
+    }
+    void list_old_peers(std::vector<PeerId> *old_peers) const {
+      old_peers->clear();
+      std::set<PeerId>::iterator it;
+      for (it = _old_peers.begin(); it != _old_peers.end(); ++it) {
+        old_peers->push_back(*it);
+      }
+    }
+    const char *stage_str() {
+      const char *str[] = {
+          "STAGE_NONE",
+          "STAGE_CATCHING_UP",
+          "STAGE_JOINT",
+          "STAGE_STABLE",
+      };
+      if (_stage <= STAGE_STABLE) {
+        return str[(int)_stage];
+      } else {
+        return "UNKNOWN";
+      }
+    }
+    int32_t stage() const { return _stage; }
+    void reset(butil::Status *st = NULL);
+    bool is_busy() const { return _stage != STAGE_NONE; }
+    // Start change configuration.
+    void start(const Configuration &old_conf, const Configuration &new_conf,
+               Closure *done);
+    // Invoked when this node becomes the leader, write a configuration
+    // change log as the first log
+    void flush(const Configuration &conf, const Configuration &old_conf);
+    void next_stage();
+    void on_caughtup(int64_t version, const PeerId &peer_id, bool succ);
 
-    struct LogEntryAndClosure {
-        LogEntry* entry;
-        Closure* done;
-        int64_t expected_term;
-    };
+  private:
+    NodeImpl *_node;
+    Stage _stage;
+    int _nchanges;
+    int64_t _version;
+    std::set<PeerId> _new_peers;
+    std::set<PeerId> _old_peers;
+    std::set<PeerId> _adding_peers;
+    Closure *_done;
+  };
 
-    struct AppendEntriesRpc : public butil::LinkNode<AppendEntriesRpc> {
-        brpc::Controller* cntl;
-        const AppendEntriesRequest* request;
-        AppendEntriesResponse* response;
-        google::protobuf::Closure* done;
-        int64_t receive_time_ms;
-    };
+  struct LogEntryAndClosure {
+    LogEntry *entry;
+    Closure *done;
+    int64_t expected_term;
+  };
 
-    struct HandleAppendEntriesFromCacheArg {
-        NodeImpl* node;
-        butil::LinkedList<AppendEntriesRpc> rpcs;
-    };
+  struct AppendEntriesRpc : public butil::LinkNode<AppendEntriesRpc> {
+    brpc::Controller *cntl;
+    const AppendEntriesRequest *request;
+    AppendEntriesResponse *response;
+    google::protobuf::Closure *done;
+    int64_t receive_time_ms;
+  };
 
-    // A simple cache to temporaryly store out-of-order AppendEntries requests.
-    class AppendEntriesCache {
-    public:
-        AppendEntriesCache(NodeImpl* node, int64_t version)
-            : _node(node), _timer(bthread_timer_t())
-            , _cache_version(0), _timer_version(0) {}
+  struct HandleAppendEntriesFromCacheArg {
+    NodeImpl *node;
+    butil::LinkedList<AppendEntriesRpc> rpcs;
+  };
 
-        int64_t first_index() const;
-        int64_t cache_version() const;
-        bool empty() const;
-        bool store(AppendEntriesRpc* rpc);
-        void process_runable_rpcs(int64_t local_last_index);
-        void clear();
-        void do_handle_append_entries_cache_timedout(
-                int64_t timer_version, int64_t timer_start_ms);
+  // A simple cache to temporaryly store out-of-order AppendEntries requests.
+  class AppendEntriesCache {
+  public:
+    AppendEntriesCache(NodeImpl *node, int64_t version)
+        : _node(node), _timer(bthread_timer_t()), _cache_version(0),
+          _timer_version(0) {}
 
-    private:
-        void ack_fail(AppendEntriesRpc* rpc);
-        void start_to_handle(HandleAppendEntriesFromCacheArg* arg);
-        bool start_timer();
-        void stop_timer();
+    int64_t first_index() const;
+    int64_t cache_version() const;
+    bool empty() const;
+    bool store(AppendEntriesRpc *rpc);
+    void process_runable_rpcs(int64_t local_last_index);
+    void clear();
+    void do_handle_append_entries_cache_timedout(int64_t timer_version,
+                                                 int64_t timer_start_ms);
 
-        NodeImpl* _node;
-        butil::LinkedList<AppendEntriesRpc> _rpc_queue;
-        std::map<int64_t, AppendEntriesRpc*> _rpc_map;
-        bthread_timer_t _timer;
-        int64_t _cache_version;
-        int64_t _timer_version;
-    };
+  private:
+    void ack_fail(AppendEntriesRpc *rpc);
+    void start_to_handle(HandleAppendEntriesFromCacheArg *arg);
+    bool start_timer();
+    void stop_timer();
 
-    struct DisruptedLeader {
-        DisruptedLeader() : term(-1) {}
-        DisruptedLeader(const PeerId& p, int64_t t) : peer_id(p), term(t) {}
-        PeerId peer_id;
-        int64_t term;
-    };
+    NodeImpl *_node;
+    butil::LinkedList<AppendEntriesRpc> _rpc_queue;
+    std::map<int64_t, AppendEntriesRpc *> _rpc_map;
+    bthread_timer_t _timer;
+    int64_t _cache_version;
+    int64_t _timer_version;
+  };
 
-    // A versioned ballot for vote and prevote
-    struct GrantSelfArg;
-    class VoteBallotCtx {
-    public:
-        VoteBallotCtx() : _timer(bthread_timer_t()), _version(0)
-                        , _grant_self_arg(NULL), _triggered(false) {
-        }
-        void init(NodeImpl* node, bool triggered);
-        void grant(const PeerId& peer) {
-            _ballot.grant(peer);
-        }
-        bool granted() {
-            return _ballot.granted();
-        }
-        int64_t version() {
-            return _version;
-        }
-        void start_grant_self_timer(int64_t wait_ms, NodeImpl* node);
-        void stop_grant_self_timer(NodeImpl* node);
-        void reset(NodeImpl* node);
-        bool triggered() { return _triggered; }
-        void reserve(const PeerId& peer);
-        void set_disrupted_leader(const DisruptedLeader& peer);
-        const DisruptedLeader& disrupted_leader() const;
-        void pop_grantable_peers(std::set<PeerId>* peers);
-        void set_last_log_id(const LogId& log_id);
-        const LogId& last_log_id() const;
-    private:
-        bthread_timer_t _timer;
-        Ballot _ballot;
-        // Each time the vote ctx restarted, increase the version to avoid
-        // ABA problem.
-        int64_t _version;
-        GrantSelfArg* _grant_self_arg;
-        bool _triggered;
-        std::set<PeerId> _reserved_peers;
-        DisruptedLeader _disrupted_leader;
-        LogId _last_log_id;
-    };
+  struct DisruptedLeader {
+    DisruptedLeader() : term(-1) {}
+    DisruptedLeader(const PeerId &p, int64_t t) : peer_id(p), term(t) {}
+    PeerId peer_id;
+    int64_t term;
+  };
 
-    struct GrantSelfArg {
-        NodeImpl* node;
-        int64_t vote_ctx_version;
-        VoteBallotCtx* vote_ctx;
-    };
+  // A versioned ballot for vote and prevote
+  struct GrantSelfArg;
+  class VoteBallotCtx {
+  public:
+    VoteBallotCtx()
+        : _timer(bthread_timer_t()), _version(0), _grant_self_arg(NULL),
+          _triggered(false) {}
+    void init(NodeImpl *node, bool triggered);
+    void grant(const PeerId &peer) { _ballot.grant(peer); }
+    bool granted() { return _ballot.granted(); }
+    int64_t version() { return _version; }
+    void start_grant_self_timer(int64_t wait_ms, NodeImpl *node);
+    void stop_grant_self_timer(NodeImpl *node);
+    void reset(NodeImpl *node);
+    bool triggered() { return _triggered; }
+    void reserve(const PeerId &peer);
+    void set_disrupted_leader(const DisruptedLeader &peer);
+    const DisruptedLeader &disrupted_leader() const;
+    void pop_grantable_peers(std::set<PeerId> *peers);
+    void set_last_log_id(const LogId &log_id);
+    const LogId &last_log_id() const;
 
-    State _state;
-    int64_t _current_term;
-    PeerId _leader_id;
-    PeerId _voted_id;
-    VoteBallotCtx _vote_ctx; // candidate vote ctx
-    VoteBallotCtx _pre_vote_ctx; // prevote ctx
-    ConfigurationEntry _conf;
+  private:
+    bthread_timer_t _timer;
+    Ballot _ballot;
+    // Each time the vote ctx restarted, increase the version to avoid
+    // ABA problem.
+    int64_t _version;
+    GrantSelfArg *_grant_self_arg;
+    bool _triggered;
+    std::set<PeerId> _reserved_peers;
+    DisruptedLeader _disrupted_leader;
+    LogId _last_log_id;
+  };
 
-    GroupId _group_id;
-    VersionedGroupId _v_group_id;
-    PeerId _server_id;
-    NodeOptions _options;
+  struct GrantSelfArg {
+    NodeImpl *node;
+    int64_t vote_ctx_version;
+    VoteBallotCtx *vote_ctx;
+  };
 
-    raft_mutex_t _mutex;
-    ConfigurationCtx _conf_ctx;
-    LogStorage* _log_storage;
-    RaftMetaStorage* _meta_storage;
-    ClosureQueue* _closure_queue;
-    ConfigurationManager* _config_manager;
-    LogManager* _log_manager;
-    FSMCaller* _fsm_caller;
-    BallotBox* _ballot_box;
-    SnapshotExecutor* _snapshot_executor;
-    ReplicatorGroup _replicator_group;
-    std::vector<Closure*> _shutdown_continuations;
-    ElectionTimer _election_timer;
-    VoteTimer _vote_timer;
-    StepdownTimer _stepdown_timer;
-    SnapshotTimer _snapshot_timer;
-    bthread_timer_t _transfer_timer;
-    StopTransferArg* _stop_transfer_arg;
-    bool _vote_triggered;
-    ReplicatorId _waking_candidate;
-    bthread::ExecutionQueueId<LogEntryAndClosure> _apply_queue_id;
-    bthread::ExecutionQueue<LogEntryAndClosure>::scoped_ptr_t _apply_queue;
-    AppendEntriesCache* _append_entries_cache;
-    int64_t _append_entries_cache_version;
+  State _state;
+  int64_t _current_term;
+  PeerId _leader_id;
+  PeerId _voted_id;
+  VoteBallotCtx _vote_ctx;     // candidate vote ctx
+  VoteBallotCtx _pre_vote_ctx; // prevote ctx
+  ConfigurationEntry _conf;
 
-    // for readonly mode
-    bool _node_readonly;
-    bool _majority_nodes_readonly;
+  GroupId _group_id;
+  VersionedGroupId _v_group_id;
+  PeerId _server_id;
+  NodeOptions _options;
 
-    LeaderLease _leader_lease;
-    FollowerLease _follower_lease;
+  raft_mutex_t _mutex;
+  ConfigurationCtx _conf_ctx;
+  LogStorage *_log_storage;
+  RaftMetaStorage *_meta_storage;
+  ClosureQueue *_closure_queue;
+  ConfigurationManager *_config_manager;
+  LogManager *_log_manager;
+  FSMCaller *_fsm_caller;
+  BallotBox *_ballot_box;
+  SnapshotExecutor *_snapshot_executor;
+  ReplicatorGroup _replicator_group;
+  std::vector<Closure *> _shutdown_continuations;
+  ElectionTimer _election_timer;
+  VoteTimer _vote_timer;
+  StepdownTimer _stepdown_timer;
+  SnapshotTimer _snapshot_timer;
+  bthread_timer_t _transfer_timer;
+  StopTransferArg *_stop_transfer_arg;
+  bool _vote_triggered;
+  ReplicatorId _waking_candidate;
+  bthread::ExecutionQueueId<LogEntryAndClosure> _apply_queue_id;
+  bthread::ExecutionQueue<LogEntryAndClosure>::scoped_ptr_t _apply_queue;
+  AppendEntriesCache *_append_entries_cache;
+  int64_t _append_entries_cache_version;
+
+  // for readonly mode
+  bool _node_readonly;
+  bool _majority_nodes_readonly;
+
+  LeaderLease _leader_lease;
+  FollowerLease _follower_lease;
 };
 
-}
+} // namespace braft
 
 #endif //~BRAFT_RAFT_NODE_H

--- a/src/braft/node.h
+++ b/src/braft/node.h
@@ -1,11 +1,11 @@
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,23 +19,23 @@
 #ifndef BRAFT_RAFT_NODE_H
 #define BRAFT_RAFT_NODE_H
 
+#include <set>
+#include <butil/atomic_ref_count.h>
+#include <butil/memory/ref_counted.h>
+#include <butil/iobuf.h>
+#include <bthread/execution_queue.h>
+#include <brpc/server.h>
+#include "braft/raft.h"
+#include "braft/log_manager.h"
 #include "braft/ballot_box.h"
+#include "braft/storage.h"
+#include "braft/raft_service.h"
+#include "braft/fsm_caller.h"
+#include "braft/replicator.h"
+#include "braft/util.h"
 #include "braft/closure_queue.h"
 #include "braft/configuration_manager.h"
-#include "braft/fsm_caller.h"
-#include "braft/log_manager.h"
-#include "braft/raft.h"
-#include "braft/raft_service.h"
 #include "braft/repeated_timer_task.h"
-#include "braft/replicator.h"
-#include "braft/storage.h"
-#include "braft/util.h"
-#include <brpc/server.h>
-#include <bthread/execution_queue.h>
-#include <butil/atomic_ref_count.h>
-#include <butil/iobuf.h>
-#include <butil/memory/ref_counted.h>
-#include <set>
 
 namespace braft {
 
@@ -48,506 +48,493 @@ class StopTransferArg;
 class NodeImpl;
 class NodeTimer : public RepeatedTimerTask {
 public:
-  NodeTimer() : _node(NULL) {}
-  virtual ~NodeTimer() {}
-  int init(NodeImpl *node, int timeout_ms);
-  virtual void run() = 0;
-
+    NodeTimer() : _node(NULL) {}
+    virtual ~NodeTimer() {}
+    int init(NodeImpl* node, int timeout_ms);
+    virtual void run() = 0;
 protected:
-  void on_destroy();
-  NodeImpl *_node;
+    void on_destroy();
+    NodeImpl* _node;
 };
 
 class ElectionTimer : public NodeTimer {
 protected:
-  void run();
-  int adjust_timeout_ms(int timeout_ms);
+    void run();
+    int adjust_timeout_ms(int timeout_ms);
 };
 
 class VoteTimer : public NodeTimer {
 protected:
-  void run();
-  int adjust_timeout_ms(int timeout_ms);
+    void run();
+    int adjust_timeout_ms(int timeout_ms);
 };
 
 class StepdownTimer : public NodeTimer {
 protected:
-  void run();
+    void run();
 };
 
 class SnapshotTimer : public NodeTimer {
 public:
-  SnapshotTimer() : _first_schedule(true) {}
-
+    SnapshotTimer() : _first_schedule(true) {}
 protected:
-  void run();
-  int adjust_timeout_ms(int timeout_ms);
-
+    void run();
+    int adjust_timeout_ms(int timeout_ms);
 private:
-  bool _first_schedule;
+    bool _first_schedule;
 };
 
-class BAIDU_CACHELINE_ALIGNMENT NodeImpl
-    : public butil::RefCountedThreadSafe<NodeImpl> {
-  friend class RaftServiceImpl;
-  friend class RaftStatImpl;
-  friend class FollowerStableClosure;
-  friend class ConfigurationChangeDone;
-  friend class VoteBallotCtx;
-
+class BAIDU_CACHELINE_ALIGNMENT NodeImpl 
+        : public butil::RefCountedThreadSafe<NodeImpl> {
+friend class RaftServiceImpl;
+friend class RaftStatImpl;
+friend class FollowerStableClosure;
+friend class ConfigurationChangeDone;
+friend class VoteBallotCtx;
 public:
-  NodeImpl(const GroupId &group_id, const PeerId &peer_id);
-  NodeImpl();
+    NodeImpl(const GroupId& group_id, const PeerId& peer_id);
+    NodeImpl();
 
-  NodeId node_id() const { return NodeId(_group_id, _server_id); }
+    NodeId node_id() const {
+        return NodeId(_group_id, _server_id);
+    }
 
-  PeerId leader_id() {
-    BAIDU_SCOPED_LOCK(_mutex);
-    return _leader_id;
-  }
+    PeerId leader_id() {
+        BAIDU_SCOPED_LOCK(_mutex);
+        return _leader_id;
+    }
 
-  bool is_leader() {
-    BAIDU_SCOPED_LOCK(_mutex);
-    return _state == STATE_LEADER;
-  }
+    bool is_leader() {
+        BAIDU_SCOPED_LOCK(_mutex);
+        return _state == STATE_LEADER;
+    }
 
-  // public user api
-  //
-  // init node
-  int init(const NodeOptions &options);
+    // public user api
+    //
+    // init node
+    int init(const NodeOptions& options);
 
-  // shutdown local replica
-  // done is user defined function, maybe response to client or clean some
-  // resource
-  void shutdown(Closure *done);
+    // shutdown local replica
+    // done is user defined function, maybe response to client or clean some resource
+    void shutdown(Closure* done);
 
-  // Block the thread until the node is successfully stopped.
-  void join();
+    // Block the thread until the node is successfully stopped.
+    void join();
 
-  // apply task to the replicated-state-machine
-  //
-  // About the ownership:
-  // |task.data|: for the performance consideration, we will take way the
-  //              content. If you want keep the content, copy it before call
-  //              this function
-  // |task.done|: If the data is successfully committed to the raft group. We
-  //              will pass the ownership to StateMachine::on_apply.
-  //              Otherwise we will specifit the error and call it.
-  //
-  void apply(const Task &task);
+    // apply task to the replicated-state-machine
+    //
+    // About the ownership:
+    // |task.data|: for the performance consideration, we will take way the 
+    //              content. If you want keep the content, copy it before call
+    //              this function
+    // |task.done|: If the data is successfully committed to the raft group. We
+    //              will pass the ownership to StateMachine::on_apply.
+    //              Otherwise we will specifit the error and call it.
+    //
+    void apply(const Task& task);
 
-  butil::Status list_peers(std::vector<PeerId> *peers);
+    butil::Status list_peers(std::vector<PeerId>* peers);
 
-  // @Node configuration change
-  void add_peer(const PeerId &peer, Closure *done);
-  void remove_peer(const PeerId &peer, Closure *done);
-  void change_peers(const Configuration &new_peers, Closure *done);
-  butil::Status reset_peers(const Configuration &new_peers);
+    // @Node configuration change
+    void add_peer(const PeerId& peer, Closure* done);
+    void remove_peer(const PeerId& peer, Closure* done);
+    void change_peers(const Configuration& new_peers, Closure* done);
+    butil::Status reset_peers(const Configuration& new_peers);
 
-  // trigger snapshot
-  void snapshot(Closure *done);
+    // trigger snapshot
+    void snapshot(Closure* done);
 
-  // trigger vote
-  butil::Status vote(int election_timeout);
+    // trigger vote
+    butil::Status vote(int election_timeout);
 
-  // reset the election_timeout for the very node
-  butil::Status reset_election_timeout_ms(int election_timeout_ms);
-  void reset_election_timeout_ms(int election_timeout_ms,
-                                 int max_clock_drift_ms);
+    // reset the election_timeout for the very node
+    butil::Status reset_election_timeout_ms(int election_timeout_ms);
+    void reset_election_timeout_ms(int election_timeout_ms, int max_clock_drift_ms);
 
-  // rpc request proc func
-  //
-  // handle received PreVote
-  int handle_pre_vote_request(const RequestVoteRequest *request,
-                              RequestVoteResponse *response);
-  // handle received RequestVote
-  int handle_request_vote_request(const RequestVoteRequest *request,
-                                  RequestVoteResponse *response);
+    // rpc request proc func
+    //
+    // handle received PreVote
+    int handle_pre_vote_request(const RequestVoteRequest* request,
+                                RequestVoteResponse* response);
+    // handle received RequestVote
+    int handle_request_vote_request(const RequestVoteRequest* request,
+                     RequestVoteResponse* response);
 
-  // handle received AppendEntries
-  void handle_append_entries_request(brpc::Controller *cntl,
-                                     const AppendEntriesRequest *request,
-                                     AppendEntriesResponse *response,
-                                     google::protobuf::Closure *done,
-                                     bool from_append_entries_cache = false);
+    // handle received AppendEntries
+    void handle_append_entries_request(brpc::Controller* cntl,
+                                      const AppendEntriesRequest* request,
+                                      AppendEntriesResponse* response,
+                                      google::protobuf::Closure* done,
+                                      bool from_append_entries_cache = false);
 
-  // handle received InstallSnapshot
-  void handle_install_snapshot_request(brpc::Controller *controller,
-                                       const InstallSnapshotRequest *request,
-                                       InstallSnapshotResponse *response,
-                                       google::protobuf::Closure *done);
+    // handle received InstallSnapshot
+    void handle_install_snapshot_request(brpc::Controller* controller,
+                                        const InstallSnapshotRequest* request,
+                                        InstallSnapshotResponse* response,
+                                        google::protobuf::Closure* done);
 
-  void handle_timeout_now_request(brpc::Controller *controller,
-                                  const TimeoutNowRequest *request,
-                                  TimeoutNowResponse *response,
-                                  google::protobuf::Closure *done);
-  // timer func
-  void handle_election_timeout();
-  void handle_vote_timeout();
-  void handle_stepdown_timeout();
-  void handle_snapshot_timeout();
-  void handle_transfer_timeout(int64_t term, const PeerId &peer);
+    void handle_timeout_now_request(brpc::Controller* controller,
+                                    const TimeoutNowRequest* request,
+                                    TimeoutNowResponse* response,
+                                    google::protobuf::Closure* done);
+    // timer func
+    void handle_election_timeout();
+    void handle_vote_timeout();
+    void handle_stepdown_timeout();
+    void handle_snapshot_timeout();
+    void handle_transfer_timeout(int64_t term, const PeerId& peer);
 
-  // Closure call func
-  //
-  void handle_pre_vote_response(const PeerId &peer_id, const int64_t term,
-                                const int64_t ctx_version,
-                                const RequestVoteResponse &response);
-  void handle_request_vote_response(const PeerId &peer_id, const int64_t term,
-                                    const int64_t ctx_version,
-                                    const RequestVoteResponse &response);
-  void on_caughtup(const PeerId &peer, int64_t term, int64_t version,
-                   const butil::Status &st);
-  // other func
-  //
-  // called when leader change configuration done, ref with FSMCaller
-  void on_configuration_change_done(int64_t term);
+    // Closure call func
+    //
+    void handle_pre_vote_response(const PeerId& peer_id, const int64_t term,
+                                  const int64_t ctx_version,
+                                  const RequestVoteResponse& response);
+    void handle_request_vote_response(const PeerId& peer_id, const int64_t term,
+                                      const int64_t ctx_version,
+                                      const RequestVoteResponse& response);
+    void on_caughtup(const PeerId& peer, int64_t term, 
+                     int64_t version, const butil::Status& st);
+    // other func
+    //
+    // called when leader change configuration done, ref with FSMCaller
+    void on_configuration_change_done(int64_t term);
 
-  // Called when leader lease is safe to start.
-  void leader_lease_start(int64_t lease_epoch);
+    // Called when leader lease is safe to start.
+    void leader_lease_start(int64_t lease_epoch);
 
-  // called when leader recv greater term in AppendEntriesResponse, ref with
-  // Replicator
-  int increase_term_to(int64_t new_term, const butil::Status &status);
+    // called when leader recv greater term in AppendEntriesResponse, ref with Replicator
+    int increase_term_to(int64_t new_term, const butil::Status& status);
 
-  // Temporary solution
-  void update_configuration_after_installing_snapshot();
+    // Temporary solution
+    void update_configuration_after_installing_snapshot();
 
-  void describe(std::ostream &os, bool use_html);
+    void describe(std::ostream& os, bool use_html);
+ 
+    // Get the internal status of this node, the information is mostly the same as we
+    // see from the website, which is generated by |describe| actually.
+    void get_status(NodeStatus* status);
 
-  // Get the internal status of this node, the information is mostly the same as
-  // we see from the website, which is generated by |describe| actually.
-  void get_status(NodeStatus *status);
+    // Readonly mode func
+    void enter_readonly_mode();
+    void leave_readonly_mode();
+    bool readonly();
+    int change_readonly_config(int64_t term, const PeerId& peer_id, bool readonly);
+    void check_majority_nodes_readonly();
+    void check_majority_nodes_readonly(const Configuration& conf);
 
-  // Readonly mode func
-  void enter_readonly_mode();
-  void leave_readonly_mode();
-  bool readonly();
-  int change_readonly_config(int64_t term, const PeerId &peer_id,
-                             bool readonly);
-  void check_majority_nodes_readonly();
-  void check_majority_nodes_readonly(const Configuration &conf);
+    // Lease func
+    bool is_leader_lease_valid();
+    void get_leader_lease_status(LeaderLeaseStatus* status);
 
-  // Lease func
-  bool is_leader_lease_valid();
-  void get_leader_lease_status(LeaderLeaseStatus *status);
+    // Call on_error when some error happens, after this is called.
+    // After this point:
+    //  - This node is to step down immediately if it was the leader.
+    //  - Any futuer operation except shutdown would fail, including any RPC
+    //    request.
+    void on_error(const Error& e);
 
-  // Call on_error when some error happens, after this is called.
-  // After this point:
-  //  - This node is to step down immediately if it was the leader.
-  //  - Any futuer operation except shutdown would fail, including any RPC
-  //    request.
-  void on_error(const Error &e);
+    int transfer_leadership_to(const PeerId& peer);
+    
+    butil::Status read_committed_user_log(const int64_t index, UserLog* user_log);
 
-  int transfer_leadership_to(const PeerId &peer);
+    int bootstrap(const BootstrapOptions& options);
 
-  butil::Status read_committed_user_log(const int64_t index, UserLog *user_log);
+    bool disable_cli() const { return _options.disable_cli; }
+    bool is_witness() const { return _options.witness; }
+private:
+friend class butil::RefCountedThreadSafe<NodeImpl>;
 
-  int bootstrap(const BootstrapOptions &options);
+    virtual ~NodeImpl();
+    // internal init func
+    int init_snapshot_storage();
+    int init_log_storage();
+    int init_meta_storage();
+    int init_fsm_caller(const LogId& bootstrap_index);
+    void unsafe_register_conf_change(const Configuration& old_conf,
+                                     const Configuration& new_conf,
+                                     Closure* done);
+    void stop_replicator(const std::set<PeerId>& keep,
+                         const std::set<PeerId>& drop);
 
-  bool disable_cli() const { return _options.disable_cli; }
-  bool is_witness() const { return _options.witness; }
+    // become leader
+    void become_leader();
+
+    // step down to follower, status give the reason
+    void step_down(const int64_t term, bool wakeup_a_candidate,
+                   const butil::Status& status);
+
+    // reset leader_id. 
+    // When new_leader_id is NULL, it means this node just stop following a leader; 
+    // otherwise, it means setting this node's leader_id to new_leader_id.
+    // status gives the situation under which this method is called.
+    void reset_leader_id(const PeerId& new_leader_id, const butil::Status& status);
+
+    // check weather to step_down when receiving append_entries/install_snapshot
+    // requests.
+    void check_step_down(const int64_t term, const PeerId& server_id);
+
+    // pre vote before elect_self
+    void pre_vote(std::unique_lock<raft_mutex_t>* lck, bool triggered);
+
+    // elect self to candidate
+    // If old leader has already stepped down, the candidate can vote without 
+    // taking account of leader lease
+    void elect_self(std::unique_lock<raft_mutex_t>* lck, 
+                    bool old_leader_stepped_down = false);
+
+    // grant self a vote
+    class VoteBallotCtx;
+    void grant_self(VoteBallotCtx* vote_ctx, std::unique_lock<raft_mutex_t>* lck);
+    static void on_grant_self_timedout(void* arg);
+    static void* handle_grant_self_timedout(void* arg);
+
+    // leader async apply configuration
+    void unsafe_apply_configuration(const Configuration& new_conf,
+                                    const Configuration* old_conf,
+                                    bool leader_start);
+
+    void do_snapshot(Closure* done);
+
+    void after_shutdown();
+    static void after_shutdown(NodeImpl* node);
+
+    void do_apply(butil::IOBuf& data, Closure* done);
+
+    struct LogEntryAndClosure;
+    static int execute_applying_tasks(
+                void* meta, bthread::TaskIterator<LogEntryAndClosure>& iter);
+    void apply(LogEntryAndClosure tasks[], size_t size);
+    void check_dead_nodes(const Configuration& conf, int64_t now_ms);
+    void check_witness(const Configuration& conf);
+    bool handle_out_of_order_append_entries(brpc::Controller* cntl,
+                                            const AppendEntriesRequest* request,
+                                            AppendEntriesResponse* response,
+                                            google::protobuf::Closure* done,
+                                            int64_t local_last_index);
+    void check_append_entries_cache(int64_t local_last_index);
+    void clear_append_entries_cache();
+    static void* handle_append_entries_from_cache(void* arg);
+    static void on_append_entries_cache_timedout(void* arg);
+    static void* handle_append_entries_cache_timedout(void* arg);
+
+    int64_t last_leader_active_timestamp();
+    int64_t last_leader_active_timestamp(const Configuration& conf);
+    void unsafe_reset_election_timeout_ms(int election_timeout_ms,
+                                          int max_clock_drift_ms);
+    void retry_vote_on_reserved_peers();
+    struct DisruptedLeader;
+    void request_peers_to_vote(const std::set<PeerId>& peers,
+                               const DisruptedLeader& disrupted_leader);
 
 private:
-  friend class butil::RefCountedThreadSafe<NodeImpl>;
 
-  virtual ~NodeImpl();
-  // internal init func
-  int init_snapshot_storage();
-  int init_log_storage();
-  int init_meta_storage();
-  int init_fsm_caller(const LogId &bootstrap_index);
-  void unsafe_register_conf_change(const Configuration &old_conf,
-                                   const Configuration &new_conf,
-                                   Closure *done);
-  void stop_replicator(const std::set<PeerId> &keep,
-                       const std::set<PeerId> &drop);
-
-  // become leader
-  void become_leader();
-
-  // step down to follower, status give the reason
-  // drained_closures: if non-null and flush_done_closures_after_step_down is
-  // enabled, pending closures are drained into it as (closure, usercode_in_pthread)
-  // pairs rather than scheduled inline. Caller must schedule after releasing _mutex.
-  void step_down(const int64_t term, bool wakeup_a_candidate,
-                 const butil::Status &status,
-                 std::deque<std::pair<Closure*, bool>>& drained_closures);
-
-  // reset leader_id.
-  // When new_leader_id is NULL, it means this node just stop following a
-  // leader; otherwise, it means setting this node's leader_id to new_leader_id.
-  // status gives the situation under which this method is called.
-  void reset_leader_id(const PeerId &new_leader_id,
-                       const butil::Status &status);
-
-  // check weather to step_down when receiving append_entries/install_snapshot
-  // requests.
-  void check_step_down(const int64_t term, const PeerId &server_id,
-                       std::deque<std::pair<Closure*, bool>>& drained_closures);
-
-  // pre vote before elect_self
-  void pre_vote(std::unique_lock<raft_mutex_t> *lck, bool triggered);
-
-  // elect self to candidate
-  // If old leader has already stepped down, the candidate can vote without
-  // taking account of leader lease
-  void elect_self(std::unique_lock<raft_mutex_t> *lck,
-                  bool old_leader_stepped_down = false);
-
-  // grant self a vote
-  class VoteBallotCtx;
-  void grant_self(VoteBallotCtx *vote_ctx, std::unique_lock<raft_mutex_t> *lck);
-  static void on_grant_self_timedout(void *arg);
-  static void *handle_grant_self_timedout(void *arg);
-
-  // leader async apply configuration
-  void unsafe_apply_configuration(const Configuration &new_conf,
-                                  const Configuration *old_conf,
-                                  bool leader_start);
-
-  void do_snapshot(Closure *done);
-
-  void after_shutdown();
-  static void after_shutdown(NodeImpl *node);
-
-  void do_apply(butil::IOBuf &data, Closure *done);
-
-  struct LogEntryAndClosure;
-  static int
-  execute_applying_tasks(void *meta,
-                         bthread::TaskIterator<LogEntryAndClosure> &iter);
-  void apply(LogEntryAndClosure tasks[], size_t size);
-  void check_dead_nodes(const Configuration &conf, int64_t now_ms,
-                        std::deque<std::pair<Closure*, bool>>& drained_closures);
-  void check_witness(const Configuration &conf);
-  bool handle_out_of_order_append_entries(brpc::Controller *cntl,
-                                          const AppendEntriesRequest *request,
-                                          AppendEntriesResponse *response,
-                                          google::protobuf::Closure *done,
-                                          int64_t local_last_index);
-  void check_append_entries_cache(int64_t local_last_index);
-  void clear_append_entries_cache();
-  static void *handle_append_entries_from_cache(void *arg);
-  static void on_append_entries_cache_timedout(void *arg);
-  static void *handle_append_entries_cache_timedout(void *arg);
-
-  int64_t last_leader_active_timestamp();
-  int64_t last_leader_active_timestamp(const Configuration &conf);
-  void unsafe_reset_election_timeout_ms(int election_timeout_ms,
-                                        int max_clock_drift_ms);
-  void retry_vote_on_reserved_peers();
-  struct DisruptedLeader;
-  void request_peers_to_vote(const std::set<PeerId> &peers,
-                             const DisruptedLeader &disrupted_leader);
-
-private:
-  class ConfigurationCtx {
+    class ConfigurationCtx {
     DISALLOW_COPY_AND_ASSIGN(ConfigurationCtx);
-
-  public:
-    enum Stage {
-      // Don't change the order if you are not sure about the usage
-      STAGE_NONE = 0,
-      STAGE_CATCHING_UP = 1,
-      STAGE_JOINT = 2,
-      STAGE_STABLE = 3,
+    public:
+        enum Stage {
+            // Don't change the order if you are not sure about the usage
+            STAGE_NONE = 0,
+            STAGE_CATCHING_UP = 1,
+            STAGE_JOINT = 2,
+            STAGE_STABLE = 3,
+        };
+        ConfigurationCtx(NodeImpl* node) :
+            _node(node), _stage(STAGE_NONE), _version(0), _done(NULL) {}
+        void list_new_peers(std::vector<PeerId>* new_peers) const {
+            new_peers->clear();
+            std::set<PeerId>::iterator it;
+            for (it = _new_peers.begin(); it != _new_peers.end(); ++it) {
+                new_peers->push_back(*it);
+            }
+        }
+        void list_old_peers(std::vector<PeerId>* old_peers) const {
+            old_peers->clear();
+            std::set<PeerId>::iterator it;
+            for (it = _old_peers.begin(); it != _old_peers.end(); ++it) {
+                old_peers->push_back(*it);
+            }
+        }
+        const char* stage_str() {
+            const char* str[] = {"STAGE_NONE", "STAGE_CATCHING_UP", 
+                                 "STAGE_JOINT", "STAGE_STABLE", };
+            if (_stage <= STAGE_STABLE) {
+                return str[(int)_stage];
+            } else {
+                return "UNKNOWN";
+            }
+        }
+        int32_t stage() const { return _stage; }
+        void reset(butil::Status* st = NULL);
+        bool is_busy() const { return _stage != STAGE_NONE; }
+        // Start change configuration.
+        void start(const Configuration& old_conf, 
+                   const Configuration& new_conf,
+                   Closure * done);
+        // Invoked when this node becomes the leader, write a configuration
+        // change log as the first log
+        void flush(const Configuration& conf,
+                   const Configuration& old_conf);
+        void next_stage();
+        void on_caughtup(int64_t version, const PeerId& peer_id, bool succ);
+    private:
+        NodeImpl* _node;
+        Stage _stage;
+        int _nchanges;
+        int64_t _version;
+        std::set<PeerId> _new_peers;
+        std::set<PeerId> _old_peers;
+        std::set<PeerId> _adding_peers;
+        Closure* _done;
     };
-    ConfigurationCtx(NodeImpl *node)
-        : _node(node), _stage(STAGE_NONE), _version(0), _done(NULL) {}
-    void list_new_peers(std::vector<PeerId> *new_peers) const {
-      new_peers->clear();
-      std::set<PeerId>::iterator it;
-      for (it = _new_peers.begin(); it != _new_peers.end(); ++it) {
-        new_peers->push_back(*it);
-      }
-    }
-    void list_old_peers(std::vector<PeerId> *old_peers) const {
-      old_peers->clear();
-      std::set<PeerId>::iterator it;
-      for (it = _old_peers.begin(); it != _old_peers.end(); ++it) {
-        old_peers->push_back(*it);
-      }
-    }
-    const char *stage_str() {
-      const char *str[] = {
-          "STAGE_NONE",
-          "STAGE_CATCHING_UP",
-          "STAGE_JOINT",
-          "STAGE_STABLE",
-      };
-      if (_stage <= STAGE_STABLE) {
-        return str[(int)_stage];
-      } else {
-        return "UNKNOWN";
-      }
-    }
-    int32_t stage() const { return _stage; }
-    void reset(butil::Status *st = NULL);
-    bool is_busy() const { return _stage != STAGE_NONE; }
-    // Start change configuration.
-    void start(const Configuration &old_conf, const Configuration &new_conf,
-               Closure *done);
-    // Invoked when this node becomes the leader, write a configuration
-    // change log as the first log
-    void flush(const Configuration &conf, const Configuration &old_conf);
-    void next_stage();
-    void on_caughtup(int64_t version, const PeerId &peer_id, bool succ);
 
-  private:
-    NodeImpl *_node;
-    Stage _stage;
-    int _nchanges;
-    int64_t _version;
-    std::set<PeerId> _new_peers;
-    std::set<PeerId> _old_peers;
-    std::set<PeerId> _adding_peers;
-    Closure *_done;
-  };
+    struct LogEntryAndClosure {
+        LogEntry* entry;
+        Closure* done;
+        int64_t expected_term;
+    };
 
-  struct LogEntryAndClosure {
-    LogEntry *entry;
-    Closure *done;
-    int64_t expected_term;
-  };
+    struct AppendEntriesRpc : public butil::LinkNode<AppendEntriesRpc> {
+        brpc::Controller* cntl;
+        const AppendEntriesRequest* request;
+        AppendEntriesResponse* response;
+        google::protobuf::Closure* done;
+        int64_t receive_time_ms;
+    };
 
-  struct AppendEntriesRpc : public butil::LinkNode<AppendEntriesRpc> {
-    brpc::Controller *cntl;
-    const AppendEntriesRequest *request;
-    AppendEntriesResponse *response;
-    google::protobuf::Closure *done;
-    int64_t receive_time_ms;
-  };
+    struct HandleAppendEntriesFromCacheArg {
+        NodeImpl* node;
+        butil::LinkedList<AppendEntriesRpc> rpcs;
+    };
 
-  struct HandleAppendEntriesFromCacheArg {
-    NodeImpl *node;
-    butil::LinkedList<AppendEntriesRpc> rpcs;
-  };
+    // A simple cache to temporaryly store out-of-order AppendEntries requests.
+    class AppendEntriesCache {
+    public:
+        AppendEntriesCache(NodeImpl* node, int64_t version)
+            : _node(node), _timer(bthread_timer_t())
+            , _cache_version(0), _timer_version(0) {}
 
-  // A simple cache to temporaryly store out-of-order AppendEntries requests.
-  class AppendEntriesCache {
-  public:
-    AppendEntriesCache(NodeImpl *node, int64_t version)
-        : _node(node), _timer(bthread_timer_t()), _cache_version(0),
-          _timer_version(0) {}
+        int64_t first_index() const;
+        int64_t cache_version() const;
+        bool empty() const;
+        bool store(AppendEntriesRpc* rpc);
+        void process_runable_rpcs(int64_t local_last_index);
+        void clear();
+        void do_handle_append_entries_cache_timedout(
+                int64_t timer_version, int64_t timer_start_ms);
 
-    int64_t first_index() const;
-    int64_t cache_version() const;
-    bool empty() const;
-    bool store(AppendEntriesRpc *rpc);
-    void process_runable_rpcs(int64_t local_last_index);
-    void clear();
-    void do_handle_append_entries_cache_timedout(int64_t timer_version,
-                                                 int64_t timer_start_ms);
+    private:
+        void ack_fail(AppendEntriesRpc* rpc);
+        void start_to_handle(HandleAppendEntriesFromCacheArg* arg);
+        bool start_timer();
+        void stop_timer();
 
-  private:
-    void ack_fail(AppendEntriesRpc *rpc);
-    void start_to_handle(HandleAppendEntriesFromCacheArg *arg);
-    bool start_timer();
-    void stop_timer();
+        NodeImpl* _node;
+        butil::LinkedList<AppendEntriesRpc> _rpc_queue;
+        std::map<int64_t, AppendEntriesRpc*> _rpc_map;
+        bthread_timer_t _timer;
+        int64_t _cache_version;
+        int64_t _timer_version;
+    };
 
-    NodeImpl *_node;
-    butil::LinkedList<AppendEntriesRpc> _rpc_queue;
-    std::map<int64_t, AppendEntriesRpc *> _rpc_map;
-    bthread_timer_t _timer;
-    int64_t _cache_version;
-    int64_t _timer_version;
-  };
+    struct DisruptedLeader {
+        DisruptedLeader() : term(-1) {}
+        DisruptedLeader(const PeerId& p, int64_t t) : peer_id(p), term(t) {}
+        PeerId peer_id;
+        int64_t term;
+    };
 
-  struct DisruptedLeader {
-    DisruptedLeader() : term(-1) {}
-    DisruptedLeader(const PeerId &p, int64_t t) : peer_id(p), term(t) {}
-    PeerId peer_id;
-    int64_t term;
-  };
+    // A versioned ballot for vote and prevote
+    struct GrantSelfArg;
+    class VoteBallotCtx {
+    public:
+        VoteBallotCtx() : _timer(bthread_timer_t()), _version(0)
+                        , _grant_self_arg(NULL), _triggered(false) {
+        }
+        void init(NodeImpl* node, bool triggered);
+        void grant(const PeerId& peer) {
+            _ballot.grant(peer);
+        }
+        bool granted() {
+            return _ballot.granted();
+        }
+        int64_t version() {
+            return _version;
+        }
+        void start_grant_self_timer(int64_t wait_ms, NodeImpl* node);
+        void stop_grant_self_timer(NodeImpl* node);
+        void reset(NodeImpl* node);
+        bool triggered() { return _triggered; }
+        void reserve(const PeerId& peer);
+        void set_disrupted_leader(const DisruptedLeader& peer);
+        const DisruptedLeader& disrupted_leader() const;
+        void pop_grantable_peers(std::set<PeerId>* peers);
+        void set_last_log_id(const LogId& log_id);
+        const LogId& last_log_id() const;
+    private:
+        bthread_timer_t _timer;
+        Ballot _ballot;
+        // Each time the vote ctx restarted, increase the version to avoid
+        // ABA problem.
+        int64_t _version;
+        GrantSelfArg* _grant_self_arg;
+        bool _triggered;
+        std::set<PeerId> _reserved_peers;
+        DisruptedLeader _disrupted_leader;
+        LogId _last_log_id;
+    };
 
-  // A versioned ballot for vote and prevote
-  struct GrantSelfArg;
-  class VoteBallotCtx {
-  public:
-    VoteBallotCtx()
-        : _timer(bthread_timer_t()), _version(0), _grant_self_arg(NULL),
-          _triggered(false) {}
-    void init(NodeImpl *node, bool triggered);
-    void grant(const PeerId &peer) { _ballot.grant(peer); }
-    bool granted() { return _ballot.granted(); }
-    int64_t version() { return _version; }
-    void start_grant_self_timer(int64_t wait_ms, NodeImpl *node);
-    void stop_grant_self_timer(NodeImpl *node);
-    void reset(NodeImpl *node);
-    bool triggered() { return _triggered; }
-    void reserve(const PeerId &peer);
-    void set_disrupted_leader(const DisruptedLeader &peer);
-    const DisruptedLeader &disrupted_leader() const;
-    void pop_grantable_peers(std::set<PeerId> *peers);
-    void set_last_log_id(const LogId &log_id);
-    const LogId &last_log_id() const;
+    struct GrantSelfArg {
+        NodeImpl* node;
+        int64_t vote_ctx_version;
+        VoteBallotCtx* vote_ctx;
+    };
 
-  private:
-    bthread_timer_t _timer;
-    Ballot _ballot;
-    // Each time the vote ctx restarted, increase the version to avoid
-    // ABA problem.
-    int64_t _version;
-    GrantSelfArg *_grant_self_arg;
-    bool _triggered;
-    std::set<PeerId> _reserved_peers;
-    DisruptedLeader _disrupted_leader;
-    LogId _last_log_id;
-  };
+    State _state;
+    int64_t _current_term;
+    PeerId _leader_id;
+    PeerId _voted_id;
+    VoteBallotCtx _vote_ctx; // candidate vote ctx
+    VoteBallotCtx _pre_vote_ctx; // prevote ctx
+    ConfigurationEntry _conf;
 
-  struct GrantSelfArg {
-    NodeImpl *node;
-    int64_t vote_ctx_version;
-    VoteBallotCtx *vote_ctx;
-  };
+    GroupId _group_id;
+    VersionedGroupId _v_group_id;
+    PeerId _server_id;
+    NodeOptions _options;
 
-  State _state;
-  int64_t _current_term;
-  PeerId _leader_id;
-  PeerId _voted_id;
-  VoteBallotCtx _vote_ctx;     // candidate vote ctx
-  VoteBallotCtx _pre_vote_ctx; // prevote ctx
-  ConfigurationEntry _conf;
+    raft_mutex_t _mutex;
+    ConfigurationCtx _conf_ctx;
+    LogStorage* _log_storage;
+    RaftMetaStorage* _meta_storage;
+    ClosureQueue* _closure_queue;
+    ConfigurationManager* _config_manager;
+    LogManager* _log_manager;
+    FSMCaller* _fsm_caller;
+    BallotBox* _ballot_box;
+    SnapshotExecutor* _snapshot_executor;
+    ReplicatorGroup _replicator_group;
+    std::vector<Closure*> _shutdown_continuations;
+    ElectionTimer _election_timer;
+    VoteTimer _vote_timer;
+    StepdownTimer _stepdown_timer;
+    SnapshotTimer _snapshot_timer;
+    bthread_timer_t _transfer_timer;
+    StopTransferArg* _stop_transfer_arg;
+    bool _vote_triggered;
+    ReplicatorId _waking_candidate;
+    bthread::ExecutionQueueId<LogEntryAndClosure> _apply_queue_id;
+    bthread::ExecutionQueue<LogEntryAndClosure>::scoped_ptr_t _apply_queue;
+    AppendEntriesCache* _append_entries_cache;
+    int64_t _append_entries_cache_version;
 
-  GroupId _group_id;
-  VersionedGroupId _v_group_id;
-  PeerId _server_id;
-  NodeOptions _options;
+    // for readonly mode
+    bool _node_readonly;
+    bool _majority_nodes_readonly;
 
-  raft_mutex_t _mutex;
-  ConfigurationCtx _conf_ctx;
-  LogStorage *_log_storage;
-  RaftMetaStorage *_meta_storage;
-  ClosureQueue *_closure_queue;
-  ConfigurationManager *_config_manager;
-  LogManager *_log_manager;
-  FSMCaller *_fsm_caller;
-  BallotBox *_ballot_box;
-  SnapshotExecutor *_snapshot_executor;
-  ReplicatorGroup _replicator_group;
-  std::vector<Closure *> _shutdown_continuations;
-  ElectionTimer _election_timer;
-  VoteTimer _vote_timer;
-  StepdownTimer _stepdown_timer;
-  SnapshotTimer _snapshot_timer;
-  bthread_timer_t _transfer_timer;
-  StopTransferArg *_stop_transfer_arg;
-  bool _vote_triggered;
-  ReplicatorId _waking_candidate;
-  bthread::ExecutionQueueId<LogEntryAndClosure> _apply_queue_id;
-  bthread::ExecutionQueue<LogEntryAndClosure>::scoped_ptr_t _apply_queue;
-  AppendEntriesCache *_append_entries_cache;
-  int64_t _append_entries_cache_version;
-
-  // for readonly mode
-  bool _node_readonly;
-  bool _majority_nodes_readonly;
-
-  LeaderLease _leader_lease;
-  FollowerLease _follower_lease;
+    LeaderLease _leader_lease;
+    FollowerLease _follower_lease;
 };
 
-} // namespace braft
+}
 
 #endif //~BRAFT_RAFT_NODE_H

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -605,7 +605,7 @@ struct NodeOptions {
     bool witness = false;
 
     // If true, flush done closures after leader step down.
-    // Default: false
+    // Default: true
     bool flush_done_closures_after_step_down = true;
 
     // Construct a default instance

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -603,6 +603,11 @@ struct NodeOptions {
     //     it may cause data lost because witness had truncated log entry before snapshot.
     // Default: false
     bool witness = false;
+
+    // If true, flush done closures after leader step down.
+    // Default: false
+    bool flush_done_closures_after_step_down = true;
+
     // Construct a default instance
     NodeOptions();
 

--- a/src/braft/util.cpp
+++ b/src/braft/util.cpp
@@ -47,7 +47,7 @@ namespace detail {
 typedef PercentileSamples<1022> CombinedPercentileSamples;
 
 static int64_t get_window_recorder_qps(void* arg) {
-    detail::Sample<Stat> s;
+    Sample<Stat> s;
     static_cast<RecorderWindow*>(arg)->get_span(1, &s);
     // Use floating point to avoid overflow.
     if (s.time_us <= 0) {

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -1,0 +1,160 @@
+// Reproduces a push_rq deadlock during step_down when many closures are
+// pending in ClosureQueue. Submit rate >> FSM rate makes closures pile up;
+// an AppendEntries with a higher term then triggers step_down, which calls
+// push_rq while holding NodeImpl._mutex. Workers blocked on _mutex cannot
+// drain _rq, so push_rq spins forever and the RPC never returns.
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <unistd.h>
+
+#include <braft/raft.h>
+#include <braft/util.h>
+#include <brpc/channel.h>
+#include <brpc/controller.h>
+#include <brpc/server.h>
+#include <bthread/bthread.h>
+#include <butil/endpoint.h>
+#include <butil/iobuf.h>
+#include "braft/raft.pb.h"
+
+// Slow FSM: creates FSM backpressure by sleeping per entry.
+// This makes closures accumulate in ClosureQueue faster than they commit.
+class SlowFSM : public braft::StateMachine {
+public:
+    std::atomic<bool> is_leader{false};
+    void on_apply(braft::Iterator& iter) override {
+        for (; iter.valid(); iter.next()) {
+            ::usleep(500);  // 0.5ms/entry → 2000 entries/sec FSM throughput
+        }
+    }
+    void on_leader_start(int64_t) override  { is_leader = true; }
+    void on_leader_stop(const butil::Status&) override { is_leader = false; }
+    void on_shutdown() override {}
+};
+
+class NopClosure : public braft::Closure {
+public:
+    void Run() override { delete this; }
+};
+
+struct ApplyArg {
+    braft::Node* node;
+    std::atomic<bool>* stop;
+};
+
+static void* apply_fn(void* arg) {
+    auto* a = static_cast<ApplyArg*>(arg);
+    while (!a->stop->load()) {
+        if (!a->node->is_leader()) { bthread_usleep(1000); continue; }
+        butil::IOBuf data; data.append("x");
+        braft::Task task;
+        task.data = &data;
+        task.done = new NopClosure;
+        a->node->apply(task);
+        bthread_usleep(100);
+    }
+    return nullptr;
+}
+
+class LeaderStepDownNoDeadlockTest : public testing::Test {
+protected:
+    void SetUp()    override { ::system("rm -rf /tmp/cqd_data"); }
+    void TearDown() override { ::system("rm -rf /tmp/cqd_data"); }
+};
+
+TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
+    const int kPort = 8300;
+    const std::string self_addr = "127.0.0.1:" + std::to_string(kPort);
+
+    brpc::Server server;
+    ASSERT_EQ(0, braft::add_service(&server, kPort));
+    ASSERT_EQ(0, server.Start(kPort, nullptr));
+
+    butil::EndPoint addr;
+    ASSERT_EQ(0, butil::str2endpoint(self_addr.c_str(), &addr));
+
+    braft::NodeOptions opts;
+    opts.election_timeout_ms              = 1000;
+    opts.fsm                              = new SlowFSM;
+    opts.node_owns_fsm                    = true;
+    opts.snapshot_interval_s              = -1;
+    ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr + ":0"));
+    opts.log_uri       = "local:///tmp/cqd_data/log";
+    opts.raft_meta_uri = "local:///tmp/cqd_data/raft_meta";
+    opts.snapshot_uri  = "local:///tmp/cqd_data/snapshot";
+
+    braft::Node node("cqd_group", braft::PeerId(addr));
+    ASSERT_EQ(0, node.init(opts));
+
+    for (int i = 0; i < 30 && !node.is_leader(); ++i) ::usleep(200000);
+    ASSERT_TRUE(node.is_leader()) << "did not become leader";
+
+    bthread_setconcurrency(8);
+    const int concurrency = bthread_getconcurrency();
+    const int kSubmitters = 2 * concurrency;
+    LOG(INFO) << "bthread concurrency=" << concurrency
+              << " submitters=" << kSubmitters;
+
+    std::atomic<bool> stop_flag{false};
+    ApplyArg apply_arg{&node, &stop_flag};
+    std::vector<bthread_t> bthreads;
+    for (int i = 0; i < kSubmitters; ++i) {
+        bthread_t t; bthread_start_background(&t, nullptr, apply_fn, &apply_arg);
+        bthreads.push_back(t);
+    }
+
+    // Let closures accumulate: ~80k apply/s vs ~2k FSM/s → ~78k closures/s
+    ::sleep(2);
+
+    // Trigger step_down via AppendEntries with higher term
+    brpc::Channel chan;
+    brpc::ChannelOptions copts;
+    copts.protocol = "baidu_std";
+    copts.timeout_ms = 30000;
+    copts.connect_timeout_ms = 5000;
+    ASSERT_EQ(0, chan.Init(self_addr.c_str(), &copts));
+
+    braft::AppendEntriesRequest req;
+    req.set_group_id("cqd_group");
+    req.set_server_id("127.0.0.1:9999:0:0");
+    req.set_peer_id(self_addr + ":0:0");
+    req.set_term(99999);
+    req.set_prev_log_term(99998);
+    req.set_prev_log_index(0);
+    req.set_committed_index(0);
+
+    braft::AppendEntriesResponse resp;
+    brpc::Controller cntl;
+    braft::RaftService_Stub stub(&chan);
+
+    // If deadlocked: push_rq spins forever, RPC never returns, test FAILS.
+    std::atomic<bool> rpc_done{false};
+    std::thread rpc_thread([&]() {
+        stub.append_entries(&cntl, &req, &resp, NULL);
+        rpc_done = true;
+    });
+
+    for (int i = 0; i < 100 && !rpc_done; ++i) ::usleep(100000);  // wait 10s
+
+    EXPECT_TRUE(rpc_done)
+        << "DEADLOCK: step_down did not complete within 10s. "
+           "push_rq is spinning with workers blocked on NodeImpl._mutex.";
+
+    stop_flag = true;
+    if (!rpc_done) {
+        // Deadlocked. Don't wait on threads/node — they all touch _mutex
+        // and would hang. Process exit will reap everything.
+        rpc_thread.detach();
+        return;
+    }
+    rpc_thread.join();
+    node.shutdown(nullptr);
+    node.join();
+    for (auto t : bthreads) {
+        bthread_join(t, nullptr);
+    }
+    server.Stop(0);
+    server.Join();
+}

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -21,11 +21,111 @@
 #include <butil/iobuf.h>
 #include "braft/raft.pb.h"
 
+// ── Shared base ───────────────────────────────────────────────────────────────
+
+class StepDownTestBase : public testing::Test {
+protected:
+    brpc::Server      server_;
+    braft::Node*      node_     = nullptr;
+    std::string       self_addr_;
+    std::string       group_id_;
+    int               concurrency_  = 0;
+    int               kSubmitters_  = 0;
+
+    void SetupNode(int port, const std::string& data_dir,
+                   const std::string& group_id, braft::StateMachine* fsm) {
+        group_id_ = group_id;
+        self_addr_ = "127.0.0.1:" + std::to_string(port);
+
+        ASSERT_EQ(0, braft::add_service(&server_, port));
+        ASSERT_EQ(0, server_.Start(port, nullptr));
+
+        butil::EndPoint addr;
+        ASSERT_EQ(0, butil::str2endpoint(self_addr_.c_str(), &addr));
+
+        braft::NodeOptions opts;
+        opts.election_timeout_ms = 1000;
+        opts.fsm                 = fsm;
+        opts.node_owns_fsm       = true;
+        opts.snapshot_interval_s = -1;
+        ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr_ + ":0"));
+        opts.log_uri       = "local://" + data_dir + "/log";
+        opts.raft_meta_uri = "local://" + data_dir + "/raft_meta";
+        opts.snapshot_uri  = "local://" + data_dir + "/snapshot";
+
+        node_ = new braft::Node(group_id, braft::PeerId(addr));
+        ASSERT_EQ(0, node_->init(opts));
+
+        for (int i = 0; i < 30 && !node_->is_leader(); ++i) ::usleep(200000);
+        ASSERT_TRUE(node_->is_leader()) << "did not become leader";
+
+        bthread_setconcurrency(8);
+        concurrency_ = bthread_getconcurrency();
+        kSubmitters_ = 2 * concurrency_;
+        LOG(INFO) << "bthread concurrency=" << concurrency_
+                  << " submitters=" << kSubmitters_;
+    }
+
+    // Fires step_down via a fake AppendEntries and waits up to 10s.
+    // Returns true if the RPC completed (no deadlock).
+    // On timeout the rpc_thread is detached; caller must not attempt cleanup.
+    bool FireStepDown() {
+        brpc::Channel chan;
+        brpc::ChannelOptions copts;
+        copts.protocol           = "baidu_std";
+        copts.timeout_ms         = 30000;
+        copts.connect_timeout_ms = 5000;
+        if (chan.Init(self_addr_.c_str(), &copts) != 0) return false;
+
+        braft::AppendEntriesRequest req;
+        req.set_group_id(group_id_);
+        req.set_server_id("127.0.0.1:9999:0:0");
+        req.set_peer_id(self_addr_ + ":0:0");
+        req.set_term(99999);
+        req.set_prev_log_term(99998);
+        req.set_prev_log_index(0);
+        req.set_committed_index(0);
+
+        braft::AppendEntriesResponse resp;
+        brpc::Controller cntl;
+        braft::RaftService_Stub stub(&chan);
+
+        std::atomic<bool> rpc_done{false};
+        std::thread rpc_thread([&]() {
+            stub.append_entries(&cntl, &req, &resp, nullptr);
+            rpc_done = true;
+        });
+
+        for (int i = 0; i < 100 && !rpc_done; ++i) ::usleep(100000);  // wait 10s
+
+        if (!rpc_done) {
+            rpc_thread.detach();
+            return false;
+        }
+        rpc_thread.join();
+        return true;
+    }
+
+    void TeardownNode() {
+        node_->shutdown(nullptr);
+        node_->join();
+        delete node_;
+        node_ = nullptr;
+        server_.Stop(0);
+        server_.Join();
+    }
+};
+
+// ── LeaderStepDownDoneClosureNoDeadlockTest ───────────────────────────────────
+//
+// Deadlock mechanism: NopClosure::Run() calls get_status() which acquires
+// _mutex. step_down holds _mutex while calling push_rq to spawn these closures;
+// when workers pick them up and block in get_status(), push_rq can't drain.
+
 // Blocking FSM: on_apply() parks on a condvar until release() is called.
-// While parked, no entries get committed and closures pile up in ClosureQueue.
+// While parked, closures pile up in ballot_box's ClosureQueue.
 class SlowFSM : public braft::StateMachine {
 public:
-    std::atomic<bool> is_leader{false};
     void on_apply(braft::Iterator& iter) override {
         {
             std::unique_lock<std::mutex> lk(_m);
@@ -33,34 +133,25 @@ public:
         }
         for (; iter.valid(); iter.next()) {}
     }
-    void on_leader_start(int64_t) override  { is_leader = true; }
-    void on_leader_stop(const butil::Status&) override { is_leader = false; }
+    void on_leader_start(int64_t) override  {}
+    void on_leader_stop(const butil::Status&) override {}
     void on_shutdown() override {}
 
-    // Wake all waiters and let any future on_apply() pass through.
     void release() {
-        {
-            std::lock_guard<std::mutex> lk(_m);
-            _released = true;
-        }
+        { std::lock_guard<std::mutex> lk(_m); _released = true; }
         _cv.notify_all();
     }
 private:
-    std::mutex _m;
+    std::mutex              _m;
     std::condition_variable _cv;
-    std::atomic<bool> _released{false};
+    std::atomic<bool>       _released{false};
 };
 
 class NopClosure : public braft::Closure {
 public:
     NopClosure(std::atomic<int>* pending, braft::Node* node)
-        : _pending(pending), _node(node) {
-        _pending->fetch_add(1);
-    }
+        : _pending(pending), _node(node) { _pending->fetch_add(1); }
     void Run() override {
-        // Acquiring the node lock here is what triggers the deadlock:
-        // step_down holds NodeImpl._mutex while calling push_rq to spawn these
-        // closures; when workers pick them up and block here, push_rq can't drain.
         braft::NodeStatus st;
         _node->get_status(&st);
         _pending->fetch_sub(1);
@@ -68,19 +159,17 @@ public:
     }
 private:
     std::atomic<int>* _pending;
-    braft::Node* _node;
+    braft::Node*      _node;
 };
 
 struct ApplyArg {
-    braft::Node* node;
+    braft::Node*      node;
     std::atomic<bool>* stop;
-    std::atomic<int>* pending;  // per-thread pending closures
+    std::atomic<int>*  pending;
 };
 
 static void* apply_fn(void* arg) {
     auto* a = static_cast<ApplyArg*>(arg);
-    // Stop submitting once this thread has this many closures still pending
-    // in ClosureQueue (i.e. their Run() hasn't fired yet).
     const int kPendingTarget = 10000;
     while (!a->stop->load() && a->pending->load() < kPendingTarget) {
         if (!a->node->is_leader()) { bthread_usleep(1000); continue; }
@@ -94,113 +183,161 @@ static void* apply_fn(void* arg) {
     return nullptr;
 }
 
-class LeaderStepDownNoDeadlockTest : public testing::Test {
+class LeaderStepDownNoDeadlockTest : public StepDownTestBase {
 protected:
-    void SetUp()    override { ::system("rm -rf /tmp/cqd_data"); }
-    void TearDown() override { ::system("rm -rf /tmp/cqd_data"); }
+    void SetUp()    override { ::system("rm -rf /tmp/cqd_data /tmp/sad_data"); }
+    void TearDown() override { ::system("rm -rf /tmp/cqd_data /tmp/sad_data"); }
 };
 
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
-    const int kPort = 8300;
-    const std::string self_addr = "127.0.0.1:" + std::to_string(kPort);
-
-    brpc::Server server;
-    ASSERT_EQ(0, braft::add_service(&server, kPort));
-    ASSERT_EQ(0, server.Start(kPort, nullptr));
-
-    butil::EndPoint addr;
-    ASSERT_EQ(0, butil::str2endpoint(self_addr.c_str(), &addr));
-
     SlowFSM* fsm = new SlowFSM;
-    braft::NodeOptions opts;
-    opts.election_timeout_ms              = 1000;
-    opts.fsm                              = fsm;
-    opts.node_owns_fsm                    = true;
-    opts.snapshot_interval_s              = -1;
-    ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr + ":0"));
-    opts.log_uri       = "local:///tmp/cqd_data/log";
-    opts.raft_meta_uri = "local:///tmp/cqd_data/raft_meta";
-    opts.snapshot_uri  = "local:///tmp/cqd_data/snapshot";
-
-    braft::Node node("cqd_group", braft::PeerId(addr));
-    ASSERT_EQ(0, node.init(opts));
-
-    for (int i = 0; i < 30 && !node.is_leader(); ++i) ::usleep(200000);
-    ASSERT_TRUE(node.is_leader()) << "did not become leader";
-
-    bthread_setconcurrency(8);
-    const int concurrency = bthread_getconcurrency();
-    const int kSubmitters = 2 * concurrency;
-    LOG(INFO) << "bthread concurrency=" << concurrency
-              << " submitters=" << kSubmitters;
+    SetupNode(8300, "/tmp/cqd_data", "cqd_group", fsm);
 
     std::atomic<bool> stop_flag{false};
-    // Per-thread pending counters and ApplyArgs. Heap-allocated and kept alive
-    // until the test ends — closures still in flight reference these.
     std::vector<std::unique_ptr<std::atomic<int>>> pendings;
     std::vector<ApplyArg> args;
-    pendings.reserve(kSubmitters);
-    args.reserve(kSubmitters);
-    for (int i = 0; i < kSubmitters; ++i) {
+    pendings.reserve(kSubmitters_);
+    args.reserve(kSubmitters_);
+    for (int i = 0; i < kSubmitters_; ++i) {
         pendings.emplace_back(new std::atomic<int>(0));
-        args.push_back({&node, &stop_flag, pendings.back().get()});
+        args.push_back({node_, &stop_flag, pendings.back().get()});
     }
     std::vector<bthread_t> bthreads;
-    for (int i = 0; i < kSubmitters; ++i) {
+    for (int i = 0; i < kSubmitters_; ++i) {
         bthread_t t; bthread_start_background(&t, nullptr, apply_fn, &args[i]);
         bthreads.push_back(t);
     }
 
     // Each submitter exits once its per-thread pending count hits the target.
     // FSM is parked on a condvar so nothing drains; pending counters only grow.
-    for (auto t : bthreads) { bthread_join(t, nullptr); }
-    bthreads.clear();
+    for (auto t : bthreads) bthread_join(t, nullptr);
     int total_pending = 0;
-    for (auto& p : pendings) { total_pending += p->load(); }
+    for (auto& p : pendings) total_pending += p->load();
     LOG(INFO) << "submitters exited; total pending closures=" << total_pending;
 
-    // Trigger step_down via AppendEntries with higher term
-    brpc::Channel chan;
-    brpc::ChannelOptions copts;
-    copts.protocol = "baidu_std";
-    copts.timeout_ms = 30000;
-    copts.connect_timeout_ms = 5000;
-    ASSERT_EQ(0, chan.Init(self_addr.c_str(), &copts));
-
-    braft::AppendEntriesRequest req;
-    req.set_group_id("cqd_group");
-    req.set_server_id("127.0.0.1:9999:0:0");
-    req.set_peer_id(self_addr + ":0:0");
-    req.set_term(99999);
-    req.set_prev_log_term(99998);
-    req.set_prev_log_index(0);
-    req.set_committed_index(0);
-
-    braft::AppendEntriesResponse resp;
-    brpc::Controller cntl;
-    braft::RaftService_Stub stub(&chan);
-
-    // If deadlocked: push_rq spins forever, RPC never returns, test FAILS.
-    std::atomic<bool> rpc_done{false};
-    std::thread rpc_thread([&]() {
-        stub.append_entries(&cntl, &req, &resp, NULL);
-        rpc_done = true;
-    });
-
-    // Unpark FSM right after firing step_down so closures start draining
-    // concurrently — that's the racing activity needed to trigger the deadlock.
+    // Release FSM concurrently with step_down to race drain against _mutex hold.
     fsm->release();
 
-    for (int i = 0; i < 100 && !rpc_done; ++i) ::usleep(100000);  // wait 10s
-
-    ASSERT_TRUE(rpc_done)
+    EXPECT_TRUE(FireStepDown())
         << "DEADLOCK: step_down did not complete within 10s. "
            "push_rq is spinning with workers blocked on NodeImpl._mutex.";
+    if (HasFailure()) exit(1);
 
     stop_flag = true;
-    rpc_thread.join();
-    node.shutdown(nullptr);
-    node.join();
-    server.Stop(0);
-    server.Join();
+    TeardownNode();
+}
+
+// ── LeaderStepDownSlowApplyNoDeadlockTest ─────────────────────────────────────
+//
+// Closer to the production pattern (see stack traces):
+//
+//   th1  handle_append_entries_request holds _mutex
+//          → clear_pending_tasks → push_rq spinning
+//   th2  handle_stepdown_timeout bthread blocked on _mutex
+//   th3  apply() caller bthread blocked on _mutex
+//
+// FSM is simply slow (usleep per entry). Submitter and get_status bthreads keep
+// running when step_down fires, occupying workers on _mutex — matching th2/th3.
+// We wait until every per-thread pending counter reaches the target
+// (deterministic replacement for ::sleep(2)) then fire step_down.
+
+class SimpleFSM : public braft::StateMachine {
+public:
+    void on_apply(braft::Iterator& iter) override {
+        for (; iter.valid(); iter.next()) ::usleep(500);  // ~2000 entries/sec
+    }
+    void on_leader_start(int64_t) override  {}
+    void on_leader_stop(const butil::Status&) override {}
+    void on_shutdown() override {}
+};
+
+struct SlowApplyArg {
+    braft::Node*       node;
+    std::atomic<bool>* stop;
+    std::atomic<int>*  pending;  // per-thread
+};
+
+class SimpleClosure : public braft::Closure {
+public:
+    explicit SimpleClosure(std::atomic<int>* pending) : _pending(pending) {
+        _pending->fetch_add(1);
+    }
+    void Run() override { _pending->fetch_sub(1); delete this; }
+private:
+    std::atomic<int>* _pending;
+};
+
+static void* slow_apply_fn(void* arg) {
+    auto* a = static_cast<SlowApplyArg*>(arg);
+    while (!a->stop->load()) {
+        if (!a->node->is_leader()) { bthread_usleep(1000); continue; }
+        butil::IOBuf data; data.append("x");
+        braft::Task task;
+        task.data = &data;
+        task.done = new SimpleClosure(a->pending);
+        a->node->apply(task);
+        bthread_usleep(100);
+    }
+    return nullptr;
+}
+
+static void* slow_gs_fn(void* arg) {
+    auto* a = static_cast<SlowApplyArg*>(arg);
+    while (!a->stop->load()) {
+        braft::NodeStatus st;
+        a->node->get_status(&st);
+        bthread_usleep(10);
+    }
+    return nullptr;
+}
+
+TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
+    SetupNode(8301, "/tmp/sad_data", "sad_group", new SimpleFSM);
+
+    std::atomic<bool> stop_flag{false};
+    std::vector<std::unique_ptr<std::atomic<int>>> pendings;
+    std::vector<SlowApplyArg> args;
+    pendings.reserve(kSubmitters_);
+    args.reserve(kSubmitters_);
+    for (int i = 0; i < kSubmitters_; ++i) {
+        pendings.emplace_back(new std::atomic<int>(0));
+        args.push_back({node_, &stop_flag, pendings.back().get()});
+    }
+
+    std::vector<bthread_t> bthreads;
+    for (int i = 0; i < kSubmitters_; ++i) {
+        bthread_t t; bthread_start_background(&t, nullptr, slow_apply_fn, &args[i]);
+        bthreads.push_back(t);
+    }
+    for (int i = 0; i < kSubmitters_; ++i) {
+        bthread_t t; bthread_start_background(&t, nullptr, slow_gs_fn, &args[i]);
+        bthreads.push_back(t);
+    }
+
+    // Deterministic readiness gate: every submitter must have kPerThreadTarget
+    // closures pending before we fire step_down (replaces ::sleep(2)).
+    const int kPerThreadTarget = 5000;
+    bool ready = false;
+    while (!ready) {
+        ready = true;
+        for (auto& p : pendings) {
+            if (p->load() < kPerThreadTarget) { ready = false; break; }
+        }
+        if (!ready) bthread_usleep(1000);
+    }
+    int total_pending = 0;
+    for (auto& p : pendings) total_pending += p->load();
+    LOG(INFO) << "ready: total_pending=" << total_pending
+              << " threshold=" << kSubmitters_ * kPerThreadTarget;
+
+    // Submitters and get_status bthreads remain active during step_down —
+    // they keep workers contending on _mutex, matching the production pattern.
+    EXPECT_TRUE(FireStepDown())
+        << "DEADLOCK: step_down did not complete within 10s. "
+           "push_rq is spinning with workers blocked on NodeImpl._mutex.";
+    if (HasFailure()) exit(1);
+
+    stop_flag = true;
+    for (auto t : bthreads) bthread_join(t, nullptr);
+    TeardownNode();
 }

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -192,7 +192,7 @@ protected:
 // when workers pick them up and block in get_status(), push_rq can't drain.
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
     auto* fsm = new SlowFSM;
-    setup_node(50082, "/tmp/cqd_data", "cqd_group", fsm);
+    setup_node(20082, "/tmp/cqd_data", "cqd_group", fsm);
 
     auto stop_flag = std::make_shared<std::atomic<bool>>(false);
     std::vector<std::shared_ptr<std::atomic<int>>> pendings;
@@ -276,7 +276,7 @@ static void* slow_apply_fn(void* arg) {
 // step_down holds node._mutex while calling push_rq; apply() callers block on node._mutex.
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
     auto* fsm = new SimpleFSM;
-    setup_node(50083, "/tmp/sad_data", "sad_group", fsm);
+    setup_node(20083, "/tmp/sad_data", "sad_group", fsm);
 
     auto stop_flag = std::make_shared<std::atomic<bool>>(false);
     std::vector<std::shared_ptr<std::atomic<int>>> pendings;

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -25,102 +25,100 @@
 
 class StepDownTestBase : public testing::Test {
 protected:
-    brpc::Server      server_;
-    braft::Node*      node_     = nullptr;
-    std::string       self_addr_;
-    std::string       group_id_;
-    int               concurrency_  = 0;
-    int               kSubmitters_  = 0;
+  brpc::Server server_;
+  std::shared_ptr<braft::Node> node_;
+  std::string self_addr_;
+  std::string group_id_;
+  int concurrency_ = 0;
+  int kSubmitters_ = 0;
 
-    void SetupNode(int port, const std::string& data_dir,
-                   const std::string& group_id, braft::StateMachine* fsm) {
-        group_id_ = group_id;
-        self_addr_ = "127.0.0.1:" + std::to_string(port);
+  void setup_server(int port) {
+    self_addr_ = "127.0.0.1:" + std::to_string(port);
+    ASSERT_EQ(0, braft::add_service(&server_, port));
+    ASSERT_EQ(0, server_.Start(port, nullptr));
+    LOG(INFO) << "Server listening at " << self_addr_;
+  }
 
-        ASSERT_EQ(0, braft::add_service(&server_, port));
-        ASSERT_EQ(0, server_.Start(port, nullptr));
+  void setup_node(int port, const std::string &data_dir,
+                 const std::string &group_id, braft::StateMachine *fsm) {
+    group_id_ = group_id;
+    setup_server(port);
 
-        butil::EndPoint addr;
-        ASSERT_EQ(0, butil::str2endpoint(self_addr_.c_str(), &addr));
+    butil::EndPoint addr;
+    ASSERT_EQ(0, butil::str2endpoint(self_addr_.c_str(), &addr));
 
-        braft::NodeOptions opts;
-        opts.election_timeout_ms = 1000;
-        opts.fsm                 = fsm;
-        opts.node_owns_fsm       = true;
-        opts.snapshot_interval_s = -1;
-        ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr_ + ":0"));
-        opts.log_uri       = "local://" + data_dir + "/log";
-        opts.raft_meta_uri = "local://" + data_dir + "/raft_meta";
-        opts.snapshot_uri  = "local://" + data_dir + "/snapshot";
+    braft::NodeOptions opts;
+    opts.election_timeout_ms = 1000;
+    opts.fsm = fsm;
+    opts.node_owns_fsm = true;
+    opts.snapshot_interval_s = -1;
+    ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr_ + ":0"));
+    opts.log_uri = "local://" + data_dir + "/log";
+    opts.raft_meta_uri = "local://" + data_dir + "/raft_meta";
+    opts.snapshot_uri = "local://" + data_dir + "/snapshot";
 
-        node_ = new braft::Node(group_id, braft::PeerId(addr));
-        ASSERT_EQ(0, node_->init(opts));
+    node_ = std::make_shared<braft::Node>(group_id, braft::PeerId(addr));
+    ASSERT_EQ(0, node_->init(opts));
+    ASSERT_TRUE(node_->is_leader()) << "did not become leader";
 
-        for (int i = 0; i < 30 && !node_->is_leader(); ++i) ::usleep(200000);
-        ASSERT_TRUE(node_->is_leader()) << "did not become leader";
+    bthread_setconcurrency(8);
+    concurrency_ = bthread_getconcurrency();
+    kSubmitters_ = 2 * concurrency_;
+    LOG(INFO) << "bthread concurrency=" << concurrency_
+              << " submitters=" << kSubmitters_;
+  }
 
-        bthread_setconcurrency(8);
-        concurrency_ = bthread_getconcurrency();
-        kSubmitters_ = 2 * concurrency_;
-        LOG(INFO) << "bthread concurrency=" << concurrency_
-                  << " submitters=" << kSubmitters_;
+  // Fires step_down via a fake AppendEntries and waits up to 10s.
+  // Returns true if the RPC completed (no deadlock).
+  // On timeout the rpc_thread is detached; caller must not attempt cleanup.
+  bool fire_step_down() {
+    brpc::Channel chan;
+    brpc::ChannelOptions copts;
+    copts.protocol = "baidu_std";
+    copts.timeout_ms = 30000;
+    copts.connect_timeout_ms = 5000;
+    if (chan.Init(self_addr_.c_str(), &copts) != 0) {
+      return false;
     }
 
-    // Fires step_down via a fake AppendEntries and waits up to 10s.
-    // Returns true if the RPC completed (no deadlock).
-    // On timeout the rpc_thread is detached; caller must not attempt cleanup.
-    bool FireStepDown() {
-        brpc::Channel chan;
-        brpc::ChannelOptions copts;
-        copts.protocol           = "baidu_std";
-        copts.timeout_ms         = 30000;
-        copts.connect_timeout_ms = 5000;
-        if (chan.Init(self_addr_.c_str(), &copts) != 0) return false;
+    braft::AppendEntriesRequest req;
+    req.set_group_id(group_id_);
+    req.set_server_id("127.0.0.1:0:0:0");
+    req.set_peer_id(self_addr_ + ":0:0");
+    req.set_term(99999);
+    req.set_prev_log_term(99998);
+    req.set_prev_log_index(0);
+    req.set_committed_index(0);
 
-        braft::AppendEntriesRequest req;
-        req.set_group_id(group_id_);
-        req.set_server_id("127.0.0.1:9999:0:0");
-        req.set_peer_id(self_addr_ + ":0:0");
-        req.set_term(99999);
-        req.set_prev_log_term(99998);
-        req.set_prev_log_index(0);
-        req.set_committed_index(0);
+    braft::AppendEntriesResponse resp;
+    brpc::Controller cntl;
+    braft::RaftService_Stub stub(&chan);
 
-        braft::AppendEntriesResponse resp;
-        brpc::Controller cntl;
-        braft::RaftService_Stub stub(&chan);
+    std::atomic<bool> rpc_done{false};
+    std::thread rpc_thread([&]() {
+      stub.append_entries(&cntl, &req, &resp, nullptr);
+      rpc_done = true;
+    });
 
-        std::atomic<bool> rpc_done{false};
-        std::thread rpc_thread([&]() {
-            stub.append_entries(&cntl, &req, &resp, nullptr);
-            rpc_done = true;
-        });
+    for (int i = 0; i < 100 && !rpc_done; ++i) {
+      ::usleep(100000);
+    } // wait 10s
 
-        for (int i = 0; i < 100 && !rpc_done; ++i) ::usleep(100000);  // wait 10s
-
-        if (!rpc_done) {
-            rpc_thread.detach();
-            return false;
-        }
-        rpc_thread.join();
-        return true;
+    if (!rpc_done) {
+      rpc_thread.detach();
+      return false;
     }
+    rpc_thread.join();
+    return true;
+  }
 
-    void TeardownNode() {
-        node_->shutdown(nullptr);
-        node_->join();
-        delete node_;
-        node_ = nullptr;
-        server_.Stop(0);
-        server_.Join();
-    }
+  void teardown_node() {
+    node_->shutdown(nullptr);
+    node_->join();
+    server_.Stop(0);
+    server_.Join();
+  }
 };
-
-// ── LeaderStepDownDoneClosureNoDeadlockTest ───────────────────────────────────
-//
-// Deadlock mechanism: NopClosure::Run() calls get_status() which acquires
-// _mutex. step_down holds _mutex while calling push_rq to spawn these closures;
-// when workers pick them up and block in get_status(), push_rq can't drain.
 
 // Blocking FSM: on_apply() parks on a condvar until release() is called.
 // While parked, closures pile up in ballot_box's ClosureQueue.
@@ -133,8 +131,8 @@ public:
         }
         for (; iter.valid(); iter.next()) {}
     }
-    void on_leader_start(int64_t) override  {}
-    void on_leader_stop(const butil::Status&) override {}
+    void on_leader_start(int64_t _term) override  {}
+    void on_leader_stop(const butil::Status& _status) override {}
     void on_shutdown() override {}
 
     void release() {
@@ -149,8 +147,8 @@ private:
 
 class NopClosure : public braft::Closure {
 public:
-    NopClosure(std::atomic<int>* pending, braft::Node* node)
-        : _pending(pending), _node(node) { _pending->fetch_add(1); }
+    NopClosure(std::shared_ptr<std::atomic<int>> pending, std::shared_ptr<braft::Node> node)
+        : _pending(std::move(pending)), _node(std::move(node)) { _pending->fetch_add(1); }
     void Run() override {
         braft::NodeStatus st;
         _node->get_status(&st);
@@ -158,14 +156,14 @@ public:
         delete this;
     }
 private:
-    std::atomic<int>* _pending;
-    braft::Node*      _node;
+    std::shared_ptr<std::atomic<int>> _pending;
+    std::shared_ptr<braft::Node>      _node;
 };
 
 struct ApplyArg {
-    braft::Node*      node;
-    std::atomic<bool>* stop;
-    std::atomic<int>*  pending;
+    std::shared_ptr<braft::Node>      node;
+    std::shared_ptr<std::atomic<bool>> stop;
+    std::shared_ptr<std::atomic<int>>  pending;
 };
 
 static void* apply_fn(void* arg) {
@@ -189,18 +187,21 @@ protected:
     void TearDown() override { ::system("rm -rf /tmp/cqd_data /tmp/sad_data"); }
 };
 
+// Deadlock mechanism: NopClosure::Run() calls get_status() which acquires
+// _mutex. step_down holds _mutex while calling push_rq to spawn these closures;
+// when workers pick them up and block in get_status(), push_rq can't drain.
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
-    SlowFSM* fsm = new SlowFSM;
-    SetupNode(8300, "/tmp/cqd_data", "cqd_group", fsm);
+    auto* fsm = new SlowFSM;
+    setup_node(50082, "/tmp/cqd_data", "cqd_group", fsm);
 
-    std::atomic<bool> stop_flag{false};
-    std::vector<std::unique_ptr<std::atomic<int>>> pendings;
+    auto stop_flag = std::make_shared<std::atomic<bool>>(false);
+    std::vector<std::shared_ptr<std::atomic<int>>> pendings;
     std::vector<ApplyArg> args;
     pendings.reserve(kSubmitters_);
     args.reserve(kSubmitters_);
     for (int i = 0; i < kSubmitters_; ++i) {
-        pendings.emplace_back(new std::atomic<int>(0));
-        args.push_back({node_, &stop_flag, pendings.back().get()});
+        pendings.emplace_back(std::make_shared<std::atomic<int>>(0));
+        args.push_back({node_, stop_flag, pendings.back()});
     }
     std::vector<bthread_t> bthreads;
     for (int i = 0; i < kSubmitters_; ++i) {
@@ -210,61 +211,45 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
 
     // Each submitter exits once its per-thread pending count hits the target.
     // FSM is parked on a condvar so nothing drains; pending counters only grow.
-    for (auto t : bthreads) bthread_join(t, nullptr);
-    int total_pending = 0;
-    for (auto& p : pendings) total_pending += p->load();
-    LOG(INFO) << "submitters exited; total pending closures=" << total_pending;
+    for (auto t : bthreads) { bthread_join(t, nullptr); }
 
     // Release FSM concurrently with step_down to race drain against _mutex hold.
     fsm->release();
 
-    EXPECT_TRUE(FireStepDown())
+    EXPECT_TRUE(fire_step_down())
         << "DEADLOCK: step_down did not complete within 10s. "
            "push_rq is spinning with workers blocked on NodeImpl._mutex.";
-    if (HasFailure()) exit(1);
+    if (HasFailure()) { exit(1); }
 
-    stop_flag = true;
-    TeardownNode();
+    stop_flag->store(true);
+    teardown_node();
 }
 
-// ── LeaderStepDownSlowApplyNoDeadlockTest ─────────────────────────────────────
-//
-// Closer to the production pattern (see stack traces):
-//
-//   th1  handle_append_entries_request holds _mutex
-//          → clear_pending_tasks → push_rq spinning
-//   th2  handle_stepdown_timeout bthread blocked on _mutex
-//   th3  apply() caller bthread blocked on _mutex
-//
-// FSM is simply slow (usleep per entry). Submitter and get_status bthreads keep
-// running when step_down fires, occupying workers on _mutex — matching th2/th3.
-// We wait until every per-thread pending counter reaches the target
-// (deterministic replacement for ::sleep(2)) then fire step_down.
-
+// FSM is simply slow (usleep per entry).
 class SimpleFSM : public braft::StateMachine {
 public:
     void on_apply(braft::Iterator& iter) override {
-        for (; iter.valid(); iter.next()) ::usleep(500);  // ~2000 entries/sec
+        for (; iter.valid(); iter.next()) { ::usleep(500); }  // ~2000 entries/sec
     }
-    void on_leader_start(int64_t) override  {}
-    void on_leader_stop(const butil::Status&) override {}
+    void on_leader_start(int64_t _term) override  {}
+    void on_leader_stop(const butil::Status& _status) override {}
     void on_shutdown() override {}
 };
 
 struct SlowApplyArg {
-    braft::Node*       node;
-    std::atomic<bool>* stop;
-    std::atomic<int>*  pending;  // per-thread
+    std::shared_ptr<braft::Node>       node;
+    std::shared_ptr<std::atomic<bool>> stop;
+    std::shared_ptr<std::atomic<int>>  pending;  // per-thread
 };
 
 class SimpleClosure : public braft::Closure {
 public:
-    explicit SimpleClosure(std::atomic<int>* pending) : _pending(pending) {
+    explicit SimpleClosure(std::shared_ptr<std::atomic<int>> pending) : _pending(std::move(pending)) {
         _pending->fetch_add(1);
     }
     void Run() override { _pending->fetch_sub(1); delete this; }
 private:
-    std::atomic<int>* _pending;
+    std::shared_ptr<std::atomic<int>> _pending;
 };
 
 static void* slow_apply_fn(void* arg) {
@@ -281,36 +266,24 @@ static void* slow_apply_fn(void* arg) {
     return nullptr;
 }
 
-static void* slow_gs_fn(void* arg) {
-    auto* a = static_cast<SlowApplyArg*>(arg);
-    while (!a->stop->load()) {
-        braft::NodeStatus st;
-        a->node->get_status(&st);
-        bthread_usleep(10);
-    }
-    return nullptr;
-}
-
+// Apply() caller bthreads keep running when step_down fires. This creates another deadlock:
+// step_down holds node._mutex while calling push_rq; apply() callers block on node._mutex.
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
-    SetupNode(8301, "/tmp/sad_data", "sad_group", new SimpleFSM);
+    setup_node(50083, "/tmp/sad_data", "sad_group", new SimpleFSM);
 
-    std::atomic<bool> stop_flag{false};
-    std::vector<std::unique_ptr<std::atomic<int>>> pendings;
+    auto stop_flag = std::make_shared<std::atomic<bool>>(false);
+    std::vector<std::shared_ptr<std::atomic<int>>> pendings;
     std::vector<SlowApplyArg> args;
     pendings.reserve(kSubmitters_);
     args.reserve(kSubmitters_);
     for (int i = 0; i < kSubmitters_; ++i) {
-        pendings.emplace_back(new std::atomic<int>(0));
-        args.push_back({node_, &stop_flag, pendings.back().get()});
+        pendings.emplace_back(std::make_shared<std::atomic<int>>(0));
+        args.push_back({node_, stop_flag, pendings.back()});
     }
 
     std::vector<bthread_t> bthreads;
     for (int i = 0; i < kSubmitters_; ++i) {
         bthread_t t; bthread_start_background(&t, nullptr, slow_apply_fn, &args[i]);
-        bthreads.push_back(t);
-    }
-    for (int i = 0; i < kSubmitters_; ++i) {
-        bthread_t t; bthread_start_background(&t, nullptr, slow_gs_fn, &args[i]);
         bthreads.push_back(t);
     }
 
@@ -323,21 +296,17 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
         for (auto& p : pendings) {
             if (p->load() < kPerThreadTarget) { ready = false; break; }
         }
-        if (!ready) bthread_usleep(1000);
+        if (!ready) { bthread_usleep(1000); }
     }
-    int total_pending = 0;
-    for (auto& p : pendings) total_pending += p->load();
-    LOG(INFO) << "ready: total_pending=" << total_pending
-              << " threshold=" << kSubmitters_ * kPerThreadTarget;
 
     // Submitters and get_status bthreads remain active during step_down —
     // they keep workers contending on _mutex, matching the production pattern.
-    EXPECT_TRUE(FireStepDown())
+    EXPECT_TRUE(fire_step_down())
         << "DEADLOCK: step_down did not complete within 10s. "
            "push_rq is spinning with workers blocked on NodeImpl._mutex.";
-    if (HasFailure()) exit(1);
+    if (HasFailure()) { exit(1); }
 
-    stop_flag = true;
-    for (auto t : bthreads) bthread_join(t, nullptr);
-    TeardownNode();
+    stop_flag->store(true);
+    for (auto t : bthreads) { bthread_join(t, nullptr); }
+    teardown_node();
 }

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <unistd.h>
 
@@ -19,39 +21,73 @@
 #include <butil/iobuf.h>
 #include "braft/raft.pb.h"
 
-// Slow FSM: creates FSM backpressure by sleeping per entry.
-// This makes closures accumulate in ClosureQueue faster than they commit.
+// Blocking FSM: on_apply() parks on a condvar until release() is called.
+// While parked, no entries get committed and closures pile up in ClosureQueue.
 class SlowFSM : public braft::StateMachine {
 public:
     std::atomic<bool> is_leader{false};
     void on_apply(braft::Iterator& iter) override {
-        for (; iter.valid(); iter.next()) {
-            ::usleep(500);  // 0.5ms/entry → 2000 entries/sec FSM throughput
+        {
+            std::unique_lock<std::mutex> lk(_m);
+            _cv.wait(lk, [this]{ return _released.load(); });
         }
+        for (; iter.valid(); iter.next()) {}
     }
     void on_leader_start(int64_t) override  { is_leader = true; }
     void on_leader_stop(const butil::Status&) override { is_leader = false; }
     void on_shutdown() override {}
+
+    // Wake all waiters and let any future on_apply() pass through.
+    void release() {
+        {
+            std::lock_guard<std::mutex> lk(_m);
+            _released = true;
+        }
+        _cv.notify_all();
+    }
+private:
+    std::mutex _m;
+    std::condition_variable _cv;
+    std::atomic<bool> _released{false};
 };
 
 class NopClosure : public braft::Closure {
 public:
-    void Run() override { delete this; }
+    NopClosure(std::atomic<int>* pending, braft::Node* node)
+        : _pending(pending), _node(node) {
+        _pending->fetch_add(1);
+    }
+    void Run() override {
+        // Acquiring the node lock here is what triggers the deadlock:
+        // step_down holds NodeImpl._mutex while calling push_rq to spawn these
+        // closures; when workers pick them up and block here, push_rq can't drain.
+        braft::NodeStatus st;
+        _node->get_status(&st);
+        _pending->fetch_sub(1);
+        delete this;
+    }
+private:
+    std::atomic<int>* _pending;
+    braft::Node* _node;
 };
 
 struct ApplyArg {
     braft::Node* node;
     std::atomic<bool>* stop;
+    std::atomic<int>* pending;  // per-thread pending closures
 };
 
 static void* apply_fn(void* arg) {
     auto* a = static_cast<ApplyArg*>(arg);
-    while (!a->stop->load()) {
+    // Stop submitting once this thread has this many closures still pending
+    // in ClosureQueue (i.e. their Run() hasn't fired yet).
+    const int kPendingTarget = 10000;
+    while (!a->stop->load() && a->pending->load() < kPendingTarget) {
         if (!a->node->is_leader()) { bthread_usleep(1000); continue; }
         butil::IOBuf data; data.append("x");
         braft::Task task;
         task.data = &data;
-        task.done = new NopClosure;
+        task.done = new NopClosure(a->pending, a->node);
         a->node->apply(task);
         bthread_usleep(100);
     }
@@ -75,9 +111,10 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
     butil::EndPoint addr;
     ASSERT_EQ(0, butil::str2endpoint(self_addr.c_str(), &addr));
 
+    SlowFSM* fsm = new SlowFSM;
     braft::NodeOptions opts;
     opts.election_timeout_ms              = 1000;
-    opts.fsm                              = new SlowFSM;
+    opts.fsm                              = fsm;
     opts.node_owns_fsm                    = true;
     opts.snapshot_interval_s              = -1;
     ASSERT_EQ(0, opts.initial_conf.parse_from(self_addr + ":0"));
@@ -98,15 +135,29 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
               << " submitters=" << kSubmitters;
 
     std::atomic<bool> stop_flag{false};
-    ApplyArg apply_arg{&node, &stop_flag};
+    // Per-thread pending counters and ApplyArgs. Heap-allocated and kept alive
+    // until the test ends — closures still in flight reference these.
+    std::vector<std::unique_ptr<std::atomic<int>>> pendings;
+    std::vector<ApplyArg> args;
+    pendings.reserve(kSubmitters);
+    args.reserve(kSubmitters);
+    for (int i = 0; i < kSubmitters; ++i) {
+        pendings.emplace_back(new std::atomic<int>(0));
+        args.push_back({&node, &stop_flag, pendings.back().get()});
+    }
     std::vector<bthread_t> bthreads;
     for (int i = 0; i < kSubmitters; ++i) {
-        bthread_t t; bthread_start_background(&t, nullptr, apply_fn, &apply_arg);
+        bthread_t t; bthread_start_background(&t, nullptr, apply_fn, &args[i]);
         bthreads.push_back(t);
     }
 
-    // Let closures accumulate: ~80k apply/s vs ~2k FSM/s → ~78k closures/s
-    ::sleep(2);
+    // Each submitter exits once its per-thread pending count hits the target.
+    // FSM is parked on a condvar so nothing drains; pending counters only grow.
+    for (auto t : bthreads) { bthread_join(t, nullptr); }
+    bthreads.clear();
+    int total_pending = 0;
+    for (auto& p : pendings) { total_pending += p->load(); }
+    LOG(INFO) << "submitters exited; total pending closures=" << total_pending;
 
     // Trigger step_down via AppendEntries with higher term
     brpc::Channel chan;
@@ -136,25 +187,20 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
         rpc_done = true;
     });
 
+    // Unpark FSM right after firing step_down so closures start draining
+    // concurrently — that's the racing activity needed to trigger the deadlock.
+    fsm->release();
+
     for (int i = 0; i < 100 && !rpc_done; ++i) ::usleep(100000);  // wait 10s
 
-    EXPECT_TRUE(rpc_done)
+    ASSERT_TRUE(rpc_done)
         << "DEADLOCK: step_down did not complete within 10s. "
            "push_rq is spinning with workers blocked on NodeImpl._mutex.";
 
     stop_flag = true;
-    if (!rpc_done) {
-        // Deadlocked. Don't wait on threads/node — they all touch _mutex
-        // and would hang. Process exit will reap everything.
-        rpc_thread.detach();
-        return;
-    }
     rpc_thread.join();
     node.shutdown(nullptr);
     node.join();
-    for (auto t : bthreads) {
-        bthread_join(t, nullptr);
-    }
     server.Stop(0);
     server.Join();
 }

--- a/test/test_leader_step_down_no_deadlock.cpp
+++ b/test/test_leader_step_down_no_deadlock.cpp
@@ -225,15 +225,21 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithPendingClosures) {
     teardown_node();
 }
 
-// FSM is simply slow (usleep per entry).
+// FSM is simply slow (usleep per entry) until set_fast() is called.
 class SimpleFSM : public braft::StateMachine {
 public:
     void on_apply(braft::Iterator& iter) override {
-        for (; iter.valid(); iter.next()) { ::usleep(500); }  // ~2000 entries/sec
+        for (; iter.valid(); iter.next()) {
+            if (!_fast.load()) { ::usleep(500); }  // ~2000 entries/sec until disabled
+        }
     }
     void on_leader_start(int64_t _term) override  {}
     void on_leader_stop(const butil::Status& _status) override {}
     void on_shutdown() override {}
+
+    void set_fast() { _fast.store(true); }
+private:
+    std::atomic<bool> _fast{false};
 };
 
 struct SlowApplyArg {
@@ -269,7 +275,8 @@ static void* slow_apply_fn(void* arg) {
 // Apply() caller bthreads keep running when step_down fires. This creates another deadlock:
 // step_down holds node._mutex while calling push_rq; apply() callers block on node._mutex.
 TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
-    setup_node(50083, "/tmp/sad_data", "sad_group", new SimpleFSM);
+    auto* fsm = new SimpleFSM;
+    setup_node(50083, "/tmp/sad_data", "sad_group", fsm);
 
     auto stop_flag = std::make_shared<std::atomic<bool>>(false);
     std::vector<std::shared_ptr<std::atomic<int>>> pendings;
@@ -305,6 +312,9 @@ TEST_F(LeaderStepDownNoDeadlockTest, StepDownWithConcurrentApply) {
         << "DEADLOCK: step_down did not complete within 10s. "
            "push_rq is spinning with workers blocked on NodeImpl._mutex.";
     if (HasFailure()) { exit(1); }
+
+    // Step_down succeeded — let the FSM drain its committed backlog at full speed.
+    fsm->set_fast();
 
     stop_flag->store(true);
     for (auto t : bthreads) { bthread_join(t, nullptr); }

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -719,7 +719,8 @@ TEST_P(NodeTest, Leader_step_down_during_install_snapshot) {
                 << " step_down because of some error";
     butil::Status status;
     status.set_error(braft::ERAFTTIMEDOUT, "Majority of the group dies");
-    leader->_impl->step_down(leader->_impl->_current_term, false, status);
+    std::deque<std::pair<braft::Closure*, bool>> _tmp_closures;
+    leader->_impl->step_down(leader->_impl->_current_term, false, status, _tmp_closures);
     cond.wait(); 
     
     // add peer1 again, success 


### PR DESCRIPTION
Refs:

https://github.com/baidu/braft/issues/531
https://github.com/baidu/braft/issues/323

We observed the following braft's deadlock issue:

th1:

    #0  clock_nanosleep
    #1  nanosleep
    #2  usleep
    #3  bthread::TaskGroup::push_rq (this=0x752c72e00000, tid=4294975251)
    #4  bthread::TaskGroup::ready_to_run
    #5  bthread::TaskGroup::start_background<false>
    #6  braft::run_closure_in_bthread_nosig
    #7  braft::ClosureQueue::clear
    #8  braft::BallotBox::clear_pending_tasks
    #9  braft::NodeImpl::step_down (this=0x752c722f7000, term=418)
    #10 braft::NodeImpl::check_step_down
    #11 braft::NodeImpl::handle_append_entries_request   ← acquired mutex here (lck._M_owns=true)
    #12 braft::RaftServiceImpl::append_entries
    #13 brpc::policy::ProcessRpcRequest
    #14 brpc::ProcessInputMessage
    #15 bthread::TaskGroup::task_runner
    #16 bthread_make_fcontext


th2:

    #0  __lll_lock_wait
    #1  pthread_mutex_lock
    #2  bthread::internal::pthread_mutex_lock_internal (mutex=0x752c722f7290)
    #3  bthread::internal::pthread_mutex_lock_impl<pthread_mutex_t>
    #4  bthread::pthread_mutex_lock_impl
    #5  pthread_mutex_lock
    #6  butil::Mutex::lock
    #7  std::unique_lock<butil::Mutex>::lock
    #8  std::unique_lock<butil::Mutex>::unique_lock
    #9  braft::NodeImpl::apply (this=0x752c722f7000)    ← blocked waiting for mutex
    #10 braft::NodeImpl::execute_applying_tasks
    #11 bthread::ExecutionQueueBase::_execute
    #12 bthread::ExecutionQueueBase::start_execute
...

Thread-1 was performing step-down while thread-2 was trying to apply, thread-1 was spinning on push_rq because there was a spike of other operations running on bthreads around the same time. Therefore, thread-1 was holding NodeImpl.mutex while waiting. Meanwhile, thread-2 was trying to grab NodeImpl.mutex and cannot get it because thread-1 was holding it. Because thread-2 couldn't finish the bthread, no free bthread slot can be freed up, so thread-1 had to spin further on push_rq, causing a deadlock.

When this deadlock happens, braft completely freezes.

This PR moves the scheduling of the "done" closures to be outside of the critical session of NodeImpl.mutex. The new code only drains the closures and append them into a local RAII guard when NodeImpl.mutex was being held; the guard will schedule the closures when NodeImpl.mutex is released. The ordering is guaranteed by constructing the guard before taking the mutex.

Tests:
1. Added two UTs to exercise exactly the deadlock. When setting flush_done_closures_after_step_down=false, they both deadlocks
2. Existing tests work fine with flush_done_closures_after_step_down=true.